### PR TITLE
Update Solo Cert if it exists, otherwise create

### DIFF
--- a/app/Helpers/SMFHelper.php
+++ b/app/Helpers/SMFHelper.php
@@ -60,7 +60,14 @@ class SMFHelper
         if (!$user) return;
 
         if ($user->rating == RatingHelper::shortToInt("ADM")) {
-            static::setGroups($cid, static::findGroup("VATSIM Staff")); return;
+            if (!RoleHelper::isVATUSAStaff($cid, true)) {
+                static::setGroups($cid, static::findGroup("VATSIM Staff"));
+                return;
+            } else {
+                static::setGroups($cid, static::findGroup("VATSIM Staff"), static::findGroup("VATUSA Staff"));
+                return;
+            }
+
         }
 
         if (RoleHelper::isSeniorStaff($user->cid, $user->facility))

--- a/app/Http/Controllers/API/v2/SoloController.php
+++ b/app/Http/Controllers/API/v2/SoloController.php
@@ -112,6 +112,11 @@ class SoloController extends APIController
             return response()->api(generate_error("Malformed request"), 400);
         }
 
+        $cid = $request->input("cid");
+        if(!User::where("cid", $cid)->count()) {
+            return response()->api(generate_error("Invalid controller"), 400);
+        }
+
         $position = $request->input("position");
         if (!preg_match("/^([A-Z0-9]{2,3})_(APP|CTR)$/", $request->input("position"))) {
             return response()->api(generate_error("Malformed position"), 400);
@@ -127,11 +132,10 @@ class SoloController extends APIController
         }
 
         if (!isTest()) {
-            $solo = new SoloCert();
-            $solo->cid = $cid;
-            $solo->position = $position;
-            $solo->expires = $exp;
-            $solo->save();
+            SoloCert::updateOrCreate(
+                ['cid' => $cid, 'position' => $position],
+                ['expires' => $exp]
+            );
         }
 
         return response()->api(['status' => 'OK']);

--- a/app/Mail/SurveyAssignment.php
+++ b/app/Mail/SurveyAssignment.php
@@ -16,17 +16,17 @@ class SurveyAssignment extends Mailable
     public $user;
     public $survey;
     public $assignment;
+    public $misc;
 
     /**
      * Create a new message instance.
-     *
-     * @return void
      */
-    public function __construct(User $user, Survey $survey, \App\SurveyAssignment $assignment)
+    public function __construct(User $user, Survey $survey, \App\SurveyAssignment $assignment, array $misc = [])
     {
         $this->user = $user;
         $this->survey = $survey;
         $this->assignment = $assignment;
+        $this->misc = $misc;
     }
 
     /**

--- a/app/User.php
+++ b/app/User.php
@@ -247,8 +247,11 @@ class User extends Model implements AuthenticatableContract, JWTSubject
 
         log_action($this->cid, "Removed from $facility by $by: $msg");
 
-        if ($this->rating >= RatingHelper::shortToInt("OBS") && env('EXIT_SURVEY', null) == 1 && $facility != "ZAE" && $newfac == "ZAE") {
-            SurveyAssignment::assign(Survey::find(env('EXIT_SURVEY_ID')), $this);
+        if ($this->rating == RatingHelper::shortToInt("OBS") &&
+            env('EXIT_SURVEY', null) != null &&
+            !in_array($facility, ["ZZN","ZAE","ZHQ"]) &&
+            $newfac == "ZAE") {
+            SurveyAssignment::assign(Survey::find(env('EXIT_SURVEY_ID')), $this, ['region' => $region]);
         }
 
         $this->facility_join = Carbon::now();

--- a/app/User.php
+++ b/app/User.php
@@ -244,7 +244,7 @@ class User extends Model implements AuthenticatableContract, JWTSubject
             $by = $byuser->fullname();
         }
 
-        log_action($this->id, "Removed from $facility by $by: $msg");
+        log_action($this->cid, "Removed from $facility by $by: $msg");
 
         if ($this->rating >= RatingHelper::shortToInt("OBS") && env('EXIT_SURVEY', null) == 1 && $facility != "ZAE" && $newfac == "ZAE") {
             SurveyAssignment::assign(Survey::find(env('EXIT_SURVEY_ID')), $this);
@@ -262,8 +262,6 @@ class User extends Model implements AuthenticatableContract, JWTSubject
         $t->status = 1;
         $t->actiontext = $msg;
         $t->save();
-
-
 
         if ($this->rating >= RatingHelper::shortToInt("I1"))
             SMFHelper::createPost(7262, 82, "User Removal: " . $this->fullname() . " (" . RatingHelper::intToShort($this->rating) . ") from " . $facility, "User " . $this->fullname() . " (" . $this->cid . "/" . RatingHelper::intToShort($this->rating) . ") was removed from $facility and holds a higher rating.  Please check for demotion requirements.  [url=https://www.vatusa.net/mgt/controller/" . $this->cid . "]Member Management[/url]");


### PR DESCRIPTION
Currently, when adding a solo cert via the API, it will create a new one even if it exists. This can cause duplicates when only changing the expiration date.

This commit changes how solo certs are saved to the database. Using the updateOrCreate method, it will check if there is already a solo cert with the given CID and position; and if so, it will just update the expiration date. Otherwise, it will create the record.

It also adds a check for validity of the CID (if the given CID exists in the database)