### PR TITLE
Prevent website login without agreeing to Privacy Policy

### DIFF
--- a/app/Http/Controllers/API/v2/BucketController.php
+++ b/app/Http/Controllers/API/v2/BucketController.php
@@ -45,7 +45,7 @@ class BucketController extends APIController
      *         description="Return JSON Token.",
      *         @SWG\Schema(
      *             type="object",
-     *             @SWG\Property(property="bucket", type="object", ref="#/definitions/Bucket"),
+     *             @SWG\Property(ref="#/definitions/Bucket"),
      *        )
      *     )
      * )
@@ -104,7 +104,7 @@ class BucketController extends APIController
      *         description="Return JSON Token.",
      *         @SWG\Schema(
      *             type="object",
-     *             @SWG\Property(property="bucket", type="object", ref="#/definitions/Bucket"),
+     *             @SWG\Property(ref="#/definitions/Bucket"),
      *        )
      *     )
      * )

--- a/app/Http/Controllers/API/v2/ExamController.php
+++ b/app/Http/Controllers/API/v2/ExamController.php
@@ -373,8 +373,8 @@ class ExamController extends APIController
      *
      * @SWG\Get(
      *     path="/exams/{examid}",
-     *     summary="(DONE) Generates list of exams.",
-     *     description="(DONE) Generates list of exams.",
+     *     summary="(DONE) Get exam details",
+     *     description="(DONE) Get exam details by ID",
      *     produces={"application/json"},
      *     tags={"exam"},
      *     @SWG\Parameter(name="examid", in="path", type="string", required=true, description="Get exam details of id"),

--- a/app/Http/Controllers/API/v2/UserController.php
+++ b/app/Http/Controllers/API/v2/UserController.php
@@ -28,8 +28,8 @@ class UserController extends APIController
     /**
      * @SWG\Get(
      *     path="/user/(cid)",
-     *     summary="(DONE) Get data about user, email will be null if API Key not specified or staff role not assigned",
-     *     description="(DONE) Get data about user",
+     *     summary="(DONE) Get data about user",
+     *     description="(DONE) Get data about user, email field will be null if API Key not specified or staff role not assigned",
      *     produces={"application/json"},
      *     tags={"user"},
      *     @SWG\Parameter(name="cid",in="path",required=true,type="string",description="Cert ID"),

--- a/app/Http/Controllers/API/v2/UserController.php
+++ b/app/Http/Controllers/API/v2/UserController.php
@@ -29,7 +29,7 @@ class UserController extends APIController
      * @SWG\Get(
      *     path="/user/(cid)",
      *     summary="(DONE) Get data about user",
-     *     description="(DONE) Get data about user, email field will be null if API Key not specified or staff role not assigned",
+     *     description="(DONE) Get user's information. Email field will be null if API Key not specified or staff role not assigned. Broadcast opt in status will be null if API key is not specified.",
      *     produces={"application/json"},
      *     tags={"user"},
      *     @SWG\Parameter(name="cid",in="path",required=true,type="string",description="Cert ID"),
@@ -52,8 +52,11 @@ class UserController extends APIController
             return response()->api(generate_error("Not found"), 404);
         }
         $data = $user->toArray();
-        if (!$request->has("apikey") && !(\Auth::check() && RoleHelper::isFacilityStaff(\Auth::user()->cid, \Auth::user()->facility))) {
-            $data['email'] = null;
+        if (!$request->has("apikey")) {
+            $data['broadcast_emailOptedIn'] = null;
+            if (!(\Auth::check() && RoleHelper::isFacilityStaff(\Auth::user()->cid, \Auth::user()->facility))) {
+                $data['email'] = null;
+            }
         }
 
         return response()->api($data);

--- a/app/Http/Controllers/Login/SSOController.php
+++ b/app/Http/Controllers/Login/SSOController.php
@@ -60,7 +60,10 @@ class SSOController extends Controller
         /* Lots to check here ... but this is our multi-point redirect */
         if ($request->has('home')) {
             $request->session()->put('return', env('SSO_RETURN_HOME'));
-        } elseif ($request->has('homedev')) {
+        } elseif ($request->has('agreed')) {
+            $request->session()->put('return', env('SSO_RETURN_AGREED'));
+            $request->session()->put('fromAgreed', true);
+        } elseif($request->has('homedev')) {
             $request->session()->put('return', env('SSO_RETURN_HOMEDEV'));
         } elseif ($request->has('forums')) {
             $request->session()->put('return', env('SSO_RETURN_FORUMS'));

--- a/app/Http/Controllers/Login/SSOController.php
+++ b/app/Http/Controllers/Login/SSOController.php
@@ -37,6 +37,9 @@ class SSOController extends Controller
 
     /**
      * @param Request $request
+     *
+     * @return bool|\Illuminate\Http\RedirectResponse|\Illuminate\Routing\Redirector|mixed|void
+     * @throws \App\Classes\OAuth\SSOException
      */
     public function getIndex(Request $request) {
         if (env('APP_ENV', 'prod') != 'dev') {

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -29,7 +29,7 @@ class Kernel extends HttpKernel
      */
     protected $middlewareGroups = [
         'web' => [
-            \App\Http\Middleware\EncryptCookies::class,
+           // \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             //\Illuminate\Session\Middleware\AuthenticateSession::class,
             \Illuminate\Session\Middleware\StartSession::class,

--- a/app/User.php
+++ b/app/User.php
@@ -27,6 +27,7 @@ use Carbon\Carbon;
  *     @SWG\Property(property="updated_at", type="string"),
  *     @SWG\Property(property="flag_needbasic", type="integer", description="1 needs basic exam"),
  *     @SWG\Property(property="flag_xferOverride", type="integer", description="Has approved transfer override"),
+ *     @SWG\Property(property="flag_broadcastOptedIn", type="integer", description="Has opted in to receiving broadcast emails"),
  *     @SWG\Property(property="facility_join", type="string", description="Date joined facility (YYYY-mm-dd hh:mm:ss)"),
  *     @SWG\Property(property="promotion_eligible", type="boolean", description="Is member eligible for promotion?"),
  *     @SWG\Property(property="transfer_eligible", type="boolean", description="Is member is eligible for transfer?"),

--- a/routes/api-v2.php
+++ b/routes/api-v2.php
@@ -170,7 +170,7 @@ Route::group(['prefix' => '/survey'], function() {
  * /users
  * User functions
  */
-Route::group(['prefix' => '/users'], function() {
+Route::group(['prefix' => '/user'], function() {
     Route::get('/{cid}', 'UserController@getIndex')->where('cid', '[0-9]+');
 
     Route::get('/roles/{facility}/{role}', 'UserController@getRoleUsers')->where(['facility' => '[A-Za-z]{3}', 'role' => '[A-Za-z0-9]+']);


### PR DESCRIPTION
In accordance with GDPR, users must agree to the Privacy Policy and the methods and usages of data collection contained therein. In addition, in order to receive broadcast emails, a user must be opted in.

- Before logging in, there is a pop up to agree to the Privacy Policy. This adds the redirection to the user's profile after logging in to review their opt-in setting.
- Adds broadcast email opt-in status field to API user info (`GET /user/{cid}`). This is only present in the response when an API Key is provided.