### PR TITLE
TMU Notices

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN	addgroup -S application && adduser -SG application application && \
 		php7-curl \
 		php7-dom \
 		php7-xml \
+		php7-xmlreader \
+		php7-xmlwriter \
 		php7-json \
 		php7-phar \
 		php7-gmp \

--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
-VATUSA API
+# VATUSA API
+This repository is the API of the VATUSA website, and is the subdomain api.vatusa.net. It works in parallel to vatusa/current.
+
 
 Middleware notes:
 -----
-- auth:jwt,web - only for authenticated sessions, no CORS checks
-- Private - CORS check for only vatusa related websites, does not authenticate
-- SemiPrivate - Authenticates and if no authentication, does apikey check
-- Public - for readability only, to be phased out
-- APIKey - legacy for v1, only checks API Key in URL path
+- auth:jwt,web - Session authentication only. Does not include CORS checks.
+- Private - Only for internal calls to the API. Includes CORS checks.
+- SemiPrivate - Attempts both session authentication and API Key check.
+- Public - For readability only, to be phased out.
+- APIKey - Legacy for v1, only checks API Key in URL path.

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -36,7 +36,7 @@ class Handler extends ExceptionHandler
      *
      * This is a great spot to send exceptions to Sentry, Bugsnag, etc.
      *
-     * @param  \Exception $exception
+     * @param \Exception $exception
      *
      * @return void
      * @throws \Exception
@@ -53,8 +53,9 @@ class Handler extends ExceptionHandler
     /**
      * Render an exception into an HTTP response.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Exception  $exception
+     * @param \Illuminate\Http\Request $request
+     * @param \Exception               $exception
+     *
      * @return \Illuminate\Http\Response
      */
     public function render($request, Exception $exception)
@@ -70,9 +71,13 @@ class Handler extends ExceptionHandler
         } else {
             $status = 500;
         }
+        if (method_exists($exception, 'getSeverity') && $exception->getSeverity() == E_USER_DEPRECATED) {
+            return false;
+        }
+
         return response()->json([
-            'status' => 'error',
-            'msg' => $exception->getMessage(),
+            'status'    => 'error',
+            'msg'       => $exception->getMessage(),
             'exception' => get_class($exception)
         ], $status);
         //return parent::render($request, $exception);
@@ -82,13 +87,15 @@ class Handler extends ExceptionHandler
      * Override the unauthenicated method to return JSON and in our format.
      *
      * @param \Illuminate\Http\Request $request
-     * @param AuthenticationException $exception
+     * @param AuthenticationException  $exception
+     *
      * @return \Illuminate\Http\JsonResponse
      */
-    public function unauthenticated($request, \Illuminate\Auth\AuthenticationException $exception) {
+    public function unauthenticated($request, \Illuminate\Auth\AuthenticationException $exception)
+    {
         return response()->json([
             'status' => 'error',
-            'msg' => 'Unauthenticated'
+            'msg'    => 'Unauthenticated'
         ], 401);
     }
 }

--- a/app/Helpers/helpers.php
+++ b/app/Helpers/helpers.php
@@ -6,9 +6,11 @@ use App\Action;
  * Generate standardized JSON output
  *
  * @param mixed $data
+ *
  * @return string
  */
-function encode_json($data) {
+function encode_json($data)
+{
     return json_encode($data, JSON_NUMERIC_CHECK);
 }
 
@@ -16,27 +18,32 @@ function encode_json($data) {
  * Just to keep sane naming
  *
  * @param $data
+ *
  * @return mixed
  */
-function decode_json($data) {
+function decode_json($data)
+{
     return json_decode($data);
 }
 
 /**
  * @param string $msg
- * @param bool $asArray
+ * @param bool   $asArray
+ *
  * @return string|array
  */
-function generate_error($msg, $asArray = true) {
+function generate_error($msg, $asArray = true)
+{
     if ($asArray) {
         return [
             'status' => 'error',
-            'msg' => $msg
+            'msg'    => $msg
         ];
     }
+
     return encode_json([
         'status' => 'error',
-        'msg' => $msg
+        'msg'    => $msg
     ]);
 }
 
@@ -44,7 +51,8 @@ function generate_error($msg, $asArray = true) {
  * @param $cid
  * @param $msg
  */
-function log_action($cid, $msg) {
+function log_action($cid, $msg)
+{
     $log = new Action();
     $log->from = 0;
     $log->to = $cid;
@@ -54,13 +62,16 @@ function log_action($cid, $msg) {
 
 /**
  * @param Request $request
+ *
  * @return bool
  */
-function isTest(Request $request = null) {
-    if (!$request) { $request = request(); }
+function isTest(Request $request = null)
+{
+    if (!$request) {
+        $request = request();
+    }
     if ($request->has('test') ||
-        \App\Helpers\AuthHelper::isSandboxKey($request->input('apikey',
-        null))) {
+        \App\Helpers\AuthHelper::isSandboxKey($request->input('apikey', null))) {
         return true;
     }
 
@@ -69,6 +80,7 @@ function isTest(Request $request = null) {
 
 /**
  * @param int $length 24
+ *
  * @return string
  */
 function randomPassword($length = 24)
@@ -80,6 +92,7 @@ function randomPassword($length = 24)
         $n = rand(0, $alphaLength);
         $pass[] = $alphabet[$n];
     }
+
     return implode($pass);
 }
 
@@ -87,25 +100,25 @@ function randomPassword($length = 24)
  * @param $data_array
  * @param $xml
  */
-function arrayToXml($data_array, &$xml) {
-    foreach($data_array as $key => $value) {
-        if(is_array($value)) {
-            if(!is_numeric($key)){
+function arrayToXml($data_array, &$xml)
+{
+    foreach ($data_array as $key => $value) {
+        if (is_array($value)) {
+            if (!is_numeric($key)) {
                 $subnode = $xml->addChild("$key");
                 arrayToXml($value, $subnode);
-            }
-            else{
+            } else {
                 $subnode = $xml->addChild("item$key");
                 arrayToXml($value, $subnode);
             }
-        }
-        else {
-            $xml->addChild("$key",htmlspecialchars("$value"));
+        } else {
+            $xml->addChild("$key", htmlspecialchars("$value"));
         }
     }
 }
 
-function extract_domain($domain) {
+function extract_domain($domain)
+{
     if (preg_match("/(?P<domain>[a-z0-9][a-z0-9\-]{1,63}\.[a-z\.]{2,6})$/i", $domain, $matches)) {
         return $matches['domain'];
     } else {

--- a/app/Http/Controllers/API/v2/APIController.php
+++ b/app/Http/Controllers/API/v2/APIController.php
@@ -52,6 +52,7 @@ use \App\Http\Controllers\Controller as BaseController;
  *     @SWG\Tag(name="survey", description="Survey management"),
  *     @SWG\Tag(name="training", description="Centralized training notes - Coming soon."),
  *     @SWG\Tag(name="user",description="User account management actions"),
+ *     @SWG\Tag(name="tmu",description="Traffic Management Unit - Notices (NTOS)"),
  * )
  */
 class APIController extends BaseController {

--- a/app/Http/Controllers/API/v2/ExamController.php
+++ b/app/Http/Controllers/API/v2/ExamController.php
@@ -802,7 +802,7 @@ class ExamController extends APIController
      *     path="/exam/(id)/assign/(cid)",
      *     summary="Assign exam. [Auth]",
      *     description="Assign exam to specified controller. Requires JWT or Session Cookie. Must be instructor, senior
-     *     staff or VATUSA staff.", tags={"user","exam"}, produces={"application/json"},
+           staff or VATUSA staff.", tags={"user","exam"}, produces={"application/json"},
      *     @SWG\Parameter(name="id", in="path", type="integer", description="Exam ID"),
      *     @SWG\Parameter(name="cid", in="path", type="integer", description="VATSIM ID"),
      *     @SWG\Parameter(name="expire", in="formData", type="integer", description="Days until expiration, 7

--- a/app/Http/Controllers/API/v2/FacilityController.php
+++ b/app/Http/Controllers/API/v2/FacilityController.php
@@ -106,8 +106,9 @@ class FacilityController extends APIController
     {"cid":1245046,"name":"Toby Rice","role":"DATM"},
     {"cid":1289149,"name":"Israel Reyes","role":"FE"},
     {"cid":1152158,"name":"Taylor Broad","role":"WM"}},
-    "stats":{"controllers":19,"pendingTransfers":0}}
-     *              }
+    "stats":{"controllers":19,"pendingTransfers":0},
+    "notices":{"D01":{{"id":4,"tmu_facility_id":"D01","priority":2,"message":"Ground hold in effect until 2300Z.",
+    "expire_date":"2019-08-01 00:00:00","created_at":"2019-07-18 08:04:36","updated_at":"2019-07-18 08:04:36"}}}}}
      *         }
      *     )
      * )
@@ -136,7 +137,9 @@ class FacilityController extends APIController
 
         $data['notices'] = [];
         foreach (TMUFacility::where('id', $id)->orWhere('parent', $id)->get() as $tmu) {
-            $data['notices'][] = $tmu->tmuNotices()->get()->toArray();
+            if ($tmu->tmuNotices()->count()) {
+                $data['notices'][$tmu->id] = $tmu->tmuNotices()->get()->toArray();
+            }
         }
 
         $json = encode_json($data);

--- a/app/Http/Controllers/API/v2/FacilityController.php
+++ b/app/Http/Controllers/API/v2/FacilityController.php
@@ -8,6 +8,8 @@ use App\Helpers\RatingHelper;
 use App\Helpers\RoleHelper;
 use App\ReturnPaths;
 use App\Role;
+use App\TMUFacility;
+use App\TMUNotice;
 use App\Transfer;
 use App\User;
 use Illuminate\Http\Request;
@@ -131,6 +133,11 @@ class FacilityController extends APIController
         $data['stats']['pendingTransfers'] = Transfer::where('to', $id)->where(
             'status', Transfer::$pending
         )->count();
+
+        $data['notices'] = [];
+        foreach (TMUFacility::where('id', $id)->orWhere('parent', $id)->get() as $tmu) {
+            $data['notices'][] = $tmu->tmuNotices()->get()->toArray();
+        }
 
         $json = encode_json($data);
 
@@ -712,9 +719,9 @@ class FacilityController extends APIController
      *                     @SWG\Property(property="name", type="string"),
      *                     @SWG\Property(property="rating", type="string", description="Short string rating (S1, S2)"),
      *                     @SWG\Property(property="intRating", type="integer", description="Numeric rating (OBS = 1,
-                                                               etc)"),
+    etc)"),
      *                     @SWG\Property(property="date", type="string", description="Date transfer submitted
-                                                          (YYYY-MM-DD)"),
+    (YYYY-MM-DD)"),
      *                 ),
      *             ),
      *         ),
@@ -780,9 +787,9 @@ class FacilityController extends APIController
      * @SWG\Parameter(name="transferId", in="query", description="Transfer ID", type="integer", required=true),
      * @SWG\Parameter(name="action", in="formData", type="string", required=true, enum={"approve","reject"},
      *                                   description="Action to take on transfer request. Valid values:
-                                         approve,reject"),
+    approve,reject"),
      * @SWG\Parameter(name="reason", in="formData", type="string", description="Reason for transfer request rejection
-                                    [required for rejections]"),
+    [required for rejections]"),
      * @SWG\Response(
      *         response="400",
      *         description="Malformed request, missing required parameter",
@@ -918,7 +925,7 @@ class FacilityController extends APIController
      *                 @SWG\Property(property="id", type="integer", description="Path DB ID"),
      *                     @SWG\Property(property="order", type="integer", description="ID used in ULS query"),
      *                     @SWG\Property(property="facility_id", type="string", description="Facility assocaited with
-                                                                 path"),
+    path"),
      *                     @SWG\Property(property="url", type="string", description="Return URL")
      *                 ),
      *             ),

--- a/app/Http/Controllers/API/v2/FacilityController.php
+++ b/app/Http/Controllers/API/v2/FacilityController.php
@@ -123,12 +123,12 @@ class FacilityController extends APIController
         }
 
         if (\Cache::has("facility.$id.info")) {
-            return \Cache::get("facility.$id.info");
+            return response()->api(json_decode(\Cache::get("facility.$id.info"),true));
         }
 
-        $data = [
-            'facility' => $facility->toArray(),
-            'role'     => Role::where('facility', $facility->id)->get()->toArray(),
+        $data['facility'] = [
+            'info' => $facility->toArray(),
+            'roles'     => Role::where('facility', $facility->id)->get()->toArray(),
         ];
         $data['stats']['controllers'] = User::where('facility', $id)->count();
         $data['stats']['pendingTransfers'] = Transfer::where('to', $id)->where(
@@ -141,12 +141,9 @@ class FacilityController extends APIController
                 $data['notices'][$tmu->id] = $tmu->tmuNotices()->get()->toArray();
             }
         }
+        \Cache::put("facility.$id.info", encode_json($data), 60);
 
-        $json = encode_json($data);
-
-        \Cache::put("facility.$id.info", $json, 60);
-
-        return $json;
+        return response()->api($data);
     }
 
     /**
@@ -334,7 +331,7 @@ class FacilityController extends APIController
             }
         }
 
-        return response()->ok([$data]);
+        return response()->ok($data);
     }
 
     /**

--- a/app/Http/Controllers/API/v2/SoloController.php
+++ b/app/Http/Controllers/API/v2/SoloController.php
@@ -162,20 +162,20 @@ class SoloController extends APIController
     for API Key] ATM, DATM, TA, INS). Pass the DB ID, returned from the POST endpoint.",
      *     produces={"application/json"}, tags={"solo"},
      *     security={"apikey","jwt","session"},
-     * @SWG\Parameter(name="id", in="formData", type="integer", required=true, description="DB ID")
-     * @SWG\Response(
+     *     @SWG\Parameter(name="id", in="formData", type="integer", required=true, description="DB ID"),
+     *     @SWG\Response(
      *         response="401",
      *         description="Unauthorized",
      *         @SWG\Schema(ref="#/definitions/error"),
      *         examples={"application/json":{"status"="error","msg"="Unauthorized"}},
      *     ),
-     * @SWG\Response(
+     *     @SWG\Response(
      *         response="403",
      *         description="Forbidden",
      *         @SWG\Schema(ref="#/definitions/error"),
      *         examples={"application/json":{"status"="error","msg"="Forbidden"}},
      *     ),
-     * @SWG\Response(
+     *     @SWG\Response(
      *         response="200",
      *         description="OK",
      *         @SWG\Schema(ref="#/definitions/OK"),

--- a/app/Http/Controllers/API/v2/SoloController.php
+++ b/app/Http/Controllers/API/v2/SoloController.php
@@ -115,17 +115,17 @@ class SoloController extends APIController
         }
 
         if (!$request->has("cid") || !$request->has("position") || !$request->has("expDate")) {
-            return response()->api(generate_error("Malformed request"), 400);
+            return response()->api(generate_error("Malformed request."), 400);
         }
 
         $cid = $request->input("cid");
         if (!User::where("cid", $cid)->count()) {
-            return response()->api(generate_error("Invalid controller"), 400);
+            return response()->api(generate_error("Invalid controller."), 400);
         }
 
-        $position = $request->input("position");
+        $position = strtoupper($request->input("position"));
         if (!preg_match("/^([A-Z0-9]{2,3})_(TWR|APP|CTR)$/", $request->input("position"))) {
-            return response()->api(generate_error("Malformed position"), 400);
+            return response()->api(generate_error("Malformed position."), 400);
         }
 
         $exp = $request->input("expDate", null);
@@ -137,7 +137,11 @@ class SoloController extends APIController
         }
 
         if ($cExp->diffInDays() > 30) {
-            return response()->api(generate_error("Invalid expiration date, must be in at most 30 days"), 400);
+            return response()->api(generate_error("Invalid expiration date, must be in at most 30 days."), 400);
+        }
+
+        if($cExp->isPast()) {
+            return response()->api(generate_error("Invalid expiration date, cannot be in the past."), 400);
         }
 
         if (!isTest()) {
@@ -202,8 +206,13 @@ class SoloController extends APIController
             return response()->api(generate_error("No solo cert found with the ID provided."), 404);
         }
 
+        $solo = SoloCert::find($id);
+        if(!$solo) {
+            return response()->api(generate_error("No solo cert found with the ID provided."), 404);
+        }
+
         if (!isTest()) {
-            SoloCert::find($id)->delete();
+            $solo->delete();
         }
 
         return response()->ok();

--- a/app/Http/Controllers/API/v2/SoloController.php
+++ b/app/Http/Controllers/API/v2/SoloController.php
@@ -129,11 +129,14 @@ class SoloController extends APIController
         }
 
         $exp = $request->input("expDate", null);
-        if (!$exp || !preg_match("/^\d{4}-\d{2}-\d{2}/", $exp)) {
-            return generate_error("Malformed or missing field", false);
+        try {
+            $cExp = \Illuminate\Support\Carbon::createFromFormat('Y-m-d', $exp);
+        } catch (InvalidArgumentException $e) {
+            return response()->api(generate_error("Malformed request, invalid expire date format (Y-m-d)."),
+                400);
         }
 
-        if (Carbon::createFromFormat('Y-m-d', $exp)->diffInDays() > 30) {
+        if ($cExp->diffInDays() > 30) {
             return response()->api(generate_error("Invalid date"), 400);
         }
 

--- a/app/Http/Controllers/API/v2/TMUController.php
+++ b/app/Http/Controllers/API/v2/TMUController.php
@@ -165,8 +165,8 @@ class TMUController extends APIController
      * @SWG\Parameter(name="priority",type="string",description="Priority of notice
     (0: Low, 1: Standard, 2: Urgent)",in="formData"),
      * @SWG\Parameter(name="message",type="string",description="Notice content",in="formData"),
-     * @SWG\Parameter(name="expire_date",type="string",description="Expiration time (YYYY-MM-DD H:i:s) - "none" for no
-     *                                                                         expiration",in="formData"),
+     * @SWG\Parameter(name="expire_date",type="string",description="Expiration time (YYYY-MM-DD H:i:s) - 'none' for no
+                                                                               expiration",in="formData"),
      * @SWG\Response(
      *         response="400",
      *         description="Malformed request",

--- a/app/Http/Controllers/API/v2/TMUController.php
+++ b/app/Http/Controllers/API/v2/TMUController.php
@@ -391,15 +391,19 @@ class TMUController extends APIController
      *             type="array",
      *             @SWG\Items(
      *                 type="object",
-     *                 @SWG\Property(property="id",type="integer",description="TMU Notice ID"),
-     *                 @SWG\Property(property="tmu_facility_id",type="string",description="TMU Map ID"),
-     *                 @SWG\Property(property="priority",type="string",description="Priority of notice
+     *                 @SWG\Property(property="notices",type="array",
+     *                     @SWG\Items(type="object",
+     *                         @SWG\Property(property="id",type="integer",description="TMU Notice ID"),
+     *                         @SWG\Property(property="tmu_facility_id",type="string",description="TMU Map ID"),
+     *                         @SWG\Property(property="priority",type="string",description="Priority of notice
      *                                                                                       (0:Low,1:Standard,2:Urgent)"),
-     *                 @SWG\Property(property="message",type="string",description="Notice content"),
-     *                 @SWG\Property(property="expire_date", type="string", description="Expiration time (YYYY-MM-DD
-     *                                                       H:i:s)"),
-     *                 @SWG\Property(property="start_date", type="string", description="Expiration time (YYYY-MM-DD
-     *                                                       H:i:s)"),
+     *                         @SWG\Property(property="message",type="string",description="Notice content"),
+     *                         @SWG\Property(property="expire_date", type="string", description="Expiration time (YYYY-MM-DD
+     *                                                                                            H:i:s)"),
+     *                         @SWG\Property(property="start_date", type="string", description="Expiration time (YYYY-MM-DD
+     *                                                                                            H:i:s)")
+     *                   )
+     *                )
      *             ),
      *         ),
      *     )

--- a/app/Http/Controllers/API/v2/TMUController.php
+++ b/app/Http/Controllers/API/v2/TMUController.php
@@ -51,7 +51,7 @@ class TMUController extends APIController
             return response()->api(generate_error("Malformed request, invalid expire date format (Y-m-d H:i:s)"), 400);
         }
 
-        if (!$cExpDate->isPast()) {
+        if ($cExpDate->isPast()) {
             return response()->api(generate_error("Malformed request, expire date cannot be in the past"), 400);
         }
 
@@ -64,7 +64,7 @@ class TMUController extends APIController
             $notice->message = $message;
             $notice->priority = $priority;
             $notice->expire_date = $expdate;
-            $facility->tmuNotices()->save($notice);
+            $tmuFac->tmuNotices()->save($notice);
         }
 
         return response()->ok();
@@ -74,11 +74,11 @@ class TMUController extends APIController
     {
         $facility = $request->input('facility', null);
         $expdate = $request->input('expire_date', null);
-        $priority = $request->input('priority', 1); //default: standard priority
+        $priority = $request->input('priority', null);
         $message = $request->input('message', null);
 
         $notice = TMUNotice::find($noticeId);
-        if (!$notice->exists()) {
+        if (!$notice) {
             return response()->api(generate_error("TMU Notice does not exist."), 400);
         }
 
@@ -95,7 +95,7 @@ class TMUController extends APIController
 
         if ($facility) {
             $tmuFac = TMUFacility::find($facility);
-            if (!$tmuFac->exists()) {
+            if (!$tmuFac) {
                 return response()->api(generate_error("TMU facility does not exist"), 404);
             }
             $fac = $tmuFac->parent ? $tmuFac->parent : $tmuFac->id; //ZXX
@@ -120,7 +120,7 @@ class TMUController extends APIController
                     400);
             }
 
-            if (!$cExpDate->isPast()) {
+            if ($cExpDate->isPast()) {
                 return response()->api(generate_error("Malformed request, expire date cannot be in the past"), 400);
             }
 
@@ -148,7 +148,7 @@ class TMUController extends APIController
     public function removeNotice(Request $request, int $noticeId)
     {
         $notice = TMUNotice::find($noticeId);
-        if (!$notice->exists()) {
+        if (!$notice) {
             return response()->api(generate_error("TMU Notice does not exist."), 400);
         }
 
@@ -167,7 +167,7 @@ class TMUController extends APIController
             $notice->delete();
         }
 
-        return reponse()->ok();
+        return response()->ok();
     }
 
     public function getNotices(Request $request, string $tmufacid = null)
@@ -175,7 +175,7 @@ class TMUController extends APIController
         //TODO:: in FacilityController, get all notices for facility itself
         if ($tmufacid) {
             $tmuFac = TMUFacility::find($tmufacid);
-            if (!$tmuFac->exists()) {
+            if (!$tmuFac) {
                 return response()->api(generate_error("TMU Facility does not exist."), 400);
             }
             $notices = $tmuFac->tmuNotices()->get()->toArray();

--- a/app/Http/Controllers/API/v2/TMUController.php
+++ b/app/Http/Controllers/API/v2/TMUController.php
@@ -136,7 +136,7 @@ class TMUController extends APIController
             }
         }
 
-        if (!in_array(intval($priority), [0, 1, 2])) {
+        if (!in_array(intval($priority), [1, 2, 3])) {
             return response()->api(generate_error("Malformed request, priority must be 0, 1, or 2"), 400);
         }
 
@@ -294,7 +294,7 @@ class TMUController extends APIController
         }
 
         if ($priority) {
-            if (!in_array(intval($priority), [0, 1, 2])) {
+            if (!in_array(intval($priority), [1, 2, 3])) {
                 return response()->api(generate_error("Malformed request, priority must be 0, 1, or 2"), 400);
             }
             $notice->priority = $priority;

--- a/app/Http/Controllers/API/v2/TMUController.php
+++ b/app/Http/Controllers/API/v2/TMUController.php
@@ -6,7 +6,6 @@ use App\Helpers\AuthHelper;
 use App\Helpers\RoleHelper;
 use App\TMUFacility;
 use App\TMUNotice;
-use DateTime;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Auth;
 use InvalidArgumentException;
@@ -341,11 +340,12 @@ class TMUController extends APIController
      * ),
      * @param \Illuminate\Http\Request $request
      *
+     * @param string|null              $tmufacid
+     *
      * @return \Illuminate\Http\JsonResponse
      */
     public function getNotices(Request $request, string $tmufacid = null)
     {
-        //TODO:: in FacilityController, get all notices for facility itself
         if ($tmufacid) {
             $tmuFac = TMUFacility::find($tmufacid);
             if (!$tmuFac) {

--- a/app/Http/Controllers/API/v2/TMUController.php
+++ b/app/Http/Controllers/API/v2/TMUController.php
@@ -18,6 +18,57 @@ use Illuminate\Http\Request;
  */
 class TMUController extends APIController
 {
+
+    /**
+     * @SWG\Get(
+     *     path="/tmu/notices/(tmufacid?)",
+     *     summary="Get list of TMU Notices.",
+     *     description="Get list of TMU Notices for either all of VATUSA or for the specified TMU Map ID.",
+     *     produces={"application/json"},
+     *     tags={"tmu"},
+     *     @SWG\Parameter(name="tmufacid", in="path", type="string", description="TMU Map ID (optional)",
+     *                                     required=false),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="OK",
+     *         @SWG\Schema(
+     *             type="array",
+     *             @SWG\Items(type="object",
+     *                 @SWG\Property(property="id",type="integer",description="TMU Notice ID"),
+     *                 @SWG\Property(property="tmu_facility_id",type="string",description="TMU Map ID"),
+     *                 @SWG\Property(property="priority",type="string",description="Priority of notice
+     *                                                                               (0:Low,1:Standard,2:Urgent)"),
+     *                 @SWG\Property(property="message",type="string",description="Notice content"),
+     *                 @SWG\Property(property="expire_date", type="string", description="Expiration time (YYYY-MM-DD
+     *                                                                                            H:i:s)"),
+     *                 @SWG\Property(property="start_date", type="string", description="Expiration time (YYYY-MM-DD
+     *                                                                                            H:i:s)")
+     *                   )
+     *                )
+     *             ),
+     *         ),
+     *     )
+     * ),
+     * @param \Illuminate\Http\Request $request
+     *
+     * @param string|null              $tmufacid
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getNotices(Request $request, string $tmufacid = null)
+    {
+        if ($tmufacid) {
+            $tmuFac = TMUFacility::find($tmufacid);
+            if (!$tmuFac) {
+                return response()->api(generate_error("TMU Facility does not exist."), 400);
+            }
+            $notices = $tmuFac->tmuNotices()->get()->toArray();
+        } else {
+            $notices = TMUNotice::all()->toArray();
+        }
+
+        return response()->api($notices);
+    }
     /**
      * @SWG\Post(
      *     path="/tmu/notices",
@@ -373,59 +424,5 @@ class TMUController extends APIController
         }
 
         return response()->ok();
-    }
-
-    /**
-     * @SWG\Get(
-     *     path="/tmu/notices/(tmufacid?)",
-     *     summary="Get list of TMU Notices.",
-     *     description="Get list of TMU Notices for either all of VATUSA or for the specified TMU Map ID.",
-     *     produces={"application/json"},
-     *     tags={"tmu"},
-     *     @SWG\Parameter(name="tmufacid", in="path", type="string", description="TMU Map ID (optional)",
-     *                                     required=false),
-     *     @SWG\Response(
-     *         response="200",
-     *         description="OK",
-     *         @SWG\Schema(
-     *             type="array",
-     *             @SWG\Items(
-     *                 type="object",
-     *                 @SWG\Property(property="notices",type="array",
-     *                     @SWG\Items(type="object",
-     *                         @SWG\Property(property="id",type="integer",description="TMU Notice ID"),
-     *                         @SWG\Property(property="tmu_facility_id",type="string",description="TMU Map ID"),
-     *                         @SWG\Property(property="priority",type="string",description="Priority of notice
-     *                                                                                       (0:Low,1:Standard,2:Urgent)"),
-     *                         @SWG\Property(property="message",type="string",description="Notice content"),
-     *                         @SWG\Property(property="expire_date", type="string", description="Expiration time (YYYY-MM-DD
-     *                                                                                            H:i:s)"),
-     *                         @SWG\Property(property="start_date", type="string", description="Expiration time (YYYY-MM-DD
-     *                                                                                            H:i:s)")
-     *                   )
-     *                )
-     *             ),
-     *         ),
-     *     )
-     * ),
-     * @param \Illuminate\Http\Request $request
-     *
-     * @param string|null              $tmufacid
-     *
-     * @return \Illuminate\Http\JsonResponse
-     */
-    public function getNotices(Request $request, string $tmufacid = null)
-    {
-        if ($tmufacid) {
-            $tmuFac = TMUFacility::find($tmufacid);
-            if (!$tmuFac) {
-                return response()->api(generate_error("TMU Facility does not exist."), 400);
-            }
-            $notices = $tmuFac->tmuNotices()->get()->toArray();
-        } else {
-            $notices = TMUNotice::all()->toArray();
-        }
-
-        return response()->api(["notices" => $notices]);
     }
 }

--- a/app/Http/Controllers/API/v2/TMUController.php
+++ b/app/Http/Controllers/API/v2/TMUController.php
@@ -2,11 +2,187 @@
 
 namespace App\Http\Controllers\API\v2;
 
+use App\Helpers\AuthHelper;
+use App\TMUFacility;
+use App\TMUNotice;
+use DateTime;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Auth;
+use InvalidArgumentException;
+use Illuminate\Http\Request;
+
 /**
  * Class TMUController
  * @package App\Http\Controllers\API\v2
  */
-class TMUController  extends APIController
+class TMUController extends APIController
 {
-    //
+    public function addNotice(Request $request)
+    {
+        $facility = $request->input('facility', null); ///TMU Map Facility ID
+        $expdate = $request->input('expire_date', null);
+        $priority = $request->input('priority', 1); //Default: standard priority
+        $message = $request->input('message', null);
+
+
+        if (!$facility || !$expdate || !$message) {
+            return response()->api(generate_error("Malformed request, missing fields"), 400);
+        }
+
+        $tmuFac = TMUFacility::find($facility);
+        if (!$tmuFac->exists()) {
+            return response()->api(generate_error("TMU facility does not exist"), 404);
+        }
+
+        $fac = $tmuFac->parent ? $tmuFac->parent : $tmuFac->id; //ZXX
+        if (Auth::check()) {
+            if (Auth::user()->facility != $fac) {
+                return response()->api(generate_error("Forbidden. Cannot add notice for another ARTCC's TMU."), 403);
+            }
+        } else {
+            if (!AuthHelper::validApiKeyv2($request->input('apikey', null), $fac)) {
+                return response()->api(generate_error("Forbidden. Cannot add notice for another ARTCC's TMU."), 403);
+            }
+        }
+
+        try {
+            $cExpDate = Carbon::createFromFormat('Y-m-d H:i:s', $expdate);
+        } catch (InvalidArgumentException $e) {
+            return response()->api(generate_error("Malformed request, invalid expire date format (Y-m-d H:i:s)"), 400);
+        }
+
+        if (!$cExpDate->isPast()) {
+            return response()->api(generate_error("Malformed request, expire date cannot be in the past"), 400);
+        }
+
+        if (!in_array(intval($priority), [0, 1, 2])) {
+            return response()->api(generate_error("Malformed request, priority must be 0, 1, or 2"), 400);
+        }
+
+        if (!isTest()) {
+            $notice = new TMUNotice;
+            $notice->message = $message;
+            $notice->priority = $priority;
+            $notice->expire_date = $expdate;
+            $facility->tmuNotices()->save($notice);
+        }
+
+        return response()->ok();
+    }
+
+    public function editNotice(Request $request, int $noticeId)
+    {
+        $facility = $request->input('facility', null);
+        $expdate = $request->input('expire_date', null);
+        $priority = $request->input('priority', 1); //default: standard priority
+        $message = $request->input('message', null);
+
+        $notice = TMUNotice::find($noticeId);
+        if (!$notice->exists()) {
+            return response()->api(generate_error("TMU Notice does not exist."), 400);
+        }
+
+        $fac = $notice->tmuFacility->parent ? $notice->tmuFacility->parent : $notice->tmuFacility->id; //ZXX
+        if (Auth::check()) {
+            if (Auth::user()->facility != $fac) {
+                return response()->api(generate_error("Forbidden. Cannot edit another ARTCC's TMU."), 403);
+            }
+        } else {
+            if (!AuthHelper::validApiKeyv2($request->input('apikey', null), $fac)) {
+                return response()->api(generate_error("Forbidden. Cannot edit another ARTCC's TMU."), 403);
+            }
+        }
+
+        if ($facility) {
+            $tmuFac = TMUFacility::find($facility);
+            if (!$tmuFac->exists()) {
+                return response()->api(generate_error("TMU facility does not exist"), 404);
+            }
+            $fac = $tmuFac->parent ? $tmuFac->parent : $tmuFac->id; //ZXX
+            if (Auth::check()) {
+                if (Auth::user()->facility != $fac) {
+                    return response()->api(generate_error("Forbidden. Cannot assign to another ARTCC's TMU."), 403);
+                }
+            } else {
+                if (!AuthHelper::validApiKeyv2($request->input('apikey', null), $fac)) {
+                    return response()->api(generate_error("Forbidden. Cannot assign to another ARTCC's TMU."), 403);
+                }
+            }
+
+            $notice->tmuFacility()->associate($tmuFac);
+        }
+
+        if ($expdate) {
+            try {
+                $cExpDate = Carbon::createFromFormat('Y-m-d H:i:s', $expdate);
+            } catch (InvalidArgumentException $e) {
+                return response()->api(generate_error("Malformed request, invalid expire date format (Y-m-d H:i:s)"),
+                    400);
+            }
+
+            if (!$cExpDate->isPast()) {
+                return response()->api(generate_error("Malformed request, expire date cannot be in the past"), 400);
+            }
+
+            $notice->expire_date = $expdate;
+        }
+
+        if ($priority) {
+            if (!in_array(intval($priority), [0, 1, 2])) {
+                return response()->api(generate_error("Malformed request, priority must be 0, 1, or 2"), 400);
+            }
+            $notice->priority = $priority;
+        }
+
+        if ($message) {
+            $notice->message = $message;
+        }
+
+        if (!isTest()) {
+            $notice->save();
+        }
+
+        return response()->ok();
+    }
+
+    public function removeNotice(Request $request, int $noticeId)
+    {
+        $notice = TMUNotice::find($noticeId);
+        if (!$notice->exists()) {
+            return response()->api(generate_error("TMU Notice does not exist."), 400);
+        }
+
+        $fac = $notice->tmuFacility->parent ? $notice->tmuFacility->parent : $notice->tmuFacility->id; //ZXX
+        if (Auth::check()) {
+            if (Auth::user()->facility != $fac) {
+                return response()->api(generate_error("Forbidden. Cannot delete another ARTCC's TMU notice."), 403);
+            }
+        } else {
+            if (!AuthHelper::validApiKeyv2($request->input('apikey', null), $fac)) {
+                return response()->api(generate_error("Forbidden. Cannot edit another ARTCC's TMU notice."), 403);
+            }
+        }
+
+        if (!isTest()) {
+            $notice->delete();
+        }
+
+        return reponse()->ok();
+    }
+
+    public function getNotices(Request $request, string $tmufacid = null)
+    {
+        //TODO:: in FacilityController, get all notices for facility itself
+        if ($tmufacid) {
+            $tmuFac = TMUFacility::find($tmufacid);
+            if (!$tmuFac->exists()) {
+                return response()->api(generate_error("TMU Facility does not exist."), 400);
+            }
+            $notices = $tmuFac->tmuNotices()->get()->toArray();
+        } else {
+            $notices = TMUNotice::all()->toArray();
+        }
+
+        return response()->api(["notices" => $notices]);
+    }
 }

--- a/app/Http/Controllers/API/v2/TMUController.php
+++ b/app/Http/Controllers/API/v2/TMUController.php
@@ -39,10 +39,11 @@ class TMUController extends APIController
      *                 @SWG\Property(property="priority",type="string",description="Priority of notice
      *                                                                               (0:Low,1:Standard,2:Urgent)"),
      *                 @SWG\Property(property="message",type="string",description="Notice content"),
-     *                 @SWG\Property(property="expire_date", type="string", description="Expiration time in Zulu (YYYY-MM-DD
-                                                                                                  H:i:s)"),
+     *                 @SWG\Property(property="expire_date", type="string", description="Expiration time in Zulu
+     *                                                       (YYYY-MM-DD
+    H:i:s)"),
      *                 @SWG\Property(property="start_date", type="string", description="Start time in Zulu (YYYY-MM-DD
-                                                                                                  H:i:s)")
+    H:i:s)")
      *                   )
      *                )
      *             ),
@@ -69,6 +70,49 @@ class TMUController extends APIController
 
         return response()->api($notices);
     }
+
+    /**
+     * @SWG\Get(
+     *     path="/tmu/notice/{id}",
+     *     summary="Get TMU notice info.",
+     *     description="Get information for a specific TMU.",
+     *     produces={"application/json"},
+     *     tags={"tmu"},
+     *     @SWG\Parameter(name="tmufacid", in="path", type="string", description="TMU ID",
+     *                                     required=true),
+     *     @SWG\Response(
+     *         response="200",
+     *         description="OK",
+     *         @SWG\Schema(
+     *             type="array",
+     *             @SWG\Items(type="object",
+     *                 @SWG\Property(property="id",type="integer",description="TMU Notice ID"),
+     *                 @SWG\Property(property="tmu_facility_id",type="string",description="TMU Map ID"),
+     *                 @SWG\Property(property="priority",type="string",description="Priority of notice
+     *                                                                               (0:Low,1:Standard,2:Urgent)"),
+     *                 @SWG\Property(property="message",type="string",description="Notice content"),
+     *                 @SWG\Property(property="expire_date", type="string", description="Expiration time in Zulu
+     *                                                       (YYYY-MM-DD
+    H:i:s)"),
+     *                 @SWG\Property(property="start_date", type="string", description="Start time in Zulu (YYYY-MM-DD
+    H:i:s)")
+     *                   )
+     *                )
+     *             ),
+     *         ),
+     *     )
+     * ),
+     * @param \Illuminate\Http\Request $request
+     *
+     * @param \App\TMUNotice           $notice
+     *
+     * @return \Illuminate\Http\JsonResponse
+     */
+    public function getNotice(Request $request, TMUNotice $notice)
+    {
+        return response()->api($notice->toArray());
+    }
+
     /**
      * @SWG\Post(
      *     path="/tmu/notices",
@@ -182,7 +226,9 @@ class TMUController extends APIController
                 return response()->api(generate_error("Malformed request, expire date cannot be before start date."),
                     400);
             }
-        } else $expdate = null;
+        } else {
+            $expdate = null;
+        }
 
         if (!in_array(intval($priority), [1, 2, 3])) {
             return response()->api(generate_error("Malformed request, priority must be 1, 2, or 3"), 400);
@@ -214,7 +260,7 @@ class TMUController extends APIController
     (1: Low, 2: Standard, 3: Urgent)",in="formData"),
      * @SWG\Parameter(name="message",type="string",description="Notice content",in="formData"),
      * @SWG\Parameter(name="expire_date",type="string",description="Expiration time (YYYY-MM-DD H:i:s) - 'none' for no
-                                                                               expiration",in="formData"),
+    expiration",in="formData"),
      * @SWG\Response(
      *         response="400",
      *         description="Malformed request",
@@ -284,11 +330,13 @@ class TMUController extends APIController
             $fac = $tmuFac->parent ? $tmuFac->parent : $tmuFac->id; //ZXX
             if (Auth::check()) {
                 if (!RoleHelper::isVATUSAStaff() && Auth::user()->facility != $fac) {
-                    return response()->api(generate_error("Forbidden. Cannot assign to another ARTCC's TMU Facility."), 403);
+                    return response()->api(generate_error("Forbidden. Cannot assign to another ARTCC's TMU Facility."),
+                        403);
                 }
             } else {
                 if (!AuthHelper::validApiKeyv2($request->input('apikey', null), $fac)) {
-                    return response()->api(generate_error("Forbidden. Cannot assign to another ARTCC's TMU Facility."), 403);
+                    return response()->api(generate_error("Forbidden. Cannot assign to another ARTCC's TMU Facility."),
+                        403);
                 }
             }
 

--- a/app/Http/Controllers/API/v2/TMUController.php
+++ b/app/Http/Controllers/API/v2/TMUController.php
@@ -69,8 +69,8 @@ class TMUController extends APIController
     public function addNotice(Request $request)
     {
         $facility = $request->input('facility', null); ///TMU Map Facility ID
-        $startdate = $request->input('start_date', null);
-        $expdate = $request->input('expire_date', null);
+        $startdate = urldecode($request->input('start_date', null));
+        $expdate = urldecode($request->input('expire_date', null));
         $priority = $request->input('priority', 1); //Default: standard priority
         $message = $request->input('message', null);
 
@@ -102,24 +102,24 @@ class TMUController extends APIController
 
         if ($startdate) {
             try {
-                $cStartDate = Carbon::createFromFormat('Y-m-d H:i:s', $startdate);
+                $cStartDate = Carbon::createFromFormat('Y-m-d H:i', $startdate);
             } catch (InvalidArgumentException $e) {
-                return response()->api(generate_error("Malformed request, invalid start date format (Y-m-d H:i:s)."),
+                return response()->api(generate_error("Malformed request, invalid start date format (Y-m-d H:i)."),
                     400);
             }
             if ($cStartDate->isPast()) {
-                return response()->api(generate_error("Malformed request, start date cannot be in the past."), 400);
+                //return response()->api(generate_error("Malformed request, start date cannot be in the past."), 400);
             }
         } else {
-            $cStartDate = Carbon::now();
+            $cStartDate = Carbon::now('utc');
             $startdate = $cStartDate->format('Y-m-d H:i:s');
         }
 
         if ($expdate) {
             try {
-                $cExpDate = Carbon::createFromFormat('Y-m-d H:i:s', $expdate);
+                $cExpDate = Carbon::createFromFormat('Y-m-d H:i', $expdate);
             } catch (InvalidArgumentException $e) {
-                return response()->api(generate_error("Malformed request, invalid expire date format (Y-m-d H:i:s)"),
+                return response()->api(generate_error("Malformed request, invalid expire date format (Y-m-d H:i)"),
                     400);
             }
 
@@ -134,7 +134,7 @@ class TMUController extends APIController
                 return response()->api(generate_error("Malformed request, expire date cannot be before start date."),
                     400);
             }
-        }
+        } else $expdate = null;
 
         if (!in_array(intval($priority), [1, 2, 3])) {
             return response()->api(generate_error("Malformed request, priority must be 0, 1, or 2"), 400);

--- a/app/Http/Controllers/API/v2/TMUController.php
+++ b/app/Http/Controllers/API/v2/TMUController.php
@@ -39,10 +39,10 @@ class TMUController extends APIController
      *                 @SWG\Property(property="priority",type="string",description="Priority of notice
      *                                                                               (0:Low,1:Standard,2:Urgent)"),
      *                 @SWG\Property(property="message",type="string",description="Notice content"),
-     *                 @SWG\Property(property="expire_date", type="string", description="Expiration time (YYYY-MM-DD
-     *                                                                                            H:i:s)"),
-     *                 @SWG\Property(property="start_date", type="string", description="Expiration time (YYYY-MM-DD
-     *                                                                                            H:i:s)")
+     *                 @SWG\Property(property="expire_date", type="string", description="Expiration time in Zulu (YYYY-MM-DD
+                                                                                                  H:i:s)"),
+     *                 @SWG\Property(property="start_date", type="string", description="Start time in Zulu (YYYY-MM-DD
+                                                                                                  H:i:s)")
      *                   )
      *                )
      *             ),

--- a/app/Http/Controllers/API/v2/UserController.php
+++ b/app/Http/Controllers/API/v2/UserController.php
@@ -30,9 +30,8 @@ class UserController extends APIController
      * @SWG\Get(
      *     path="/user/(cid)",
      *     summary="Get user's information.",
-     *     description="Get user's information. Email field requires authentication as senior staff member.
-    Broadcast opt-in status requires API key or staff member authentication. Prevent Staff Assignment field requires authentication
-    as senior staff.",
+     *     description="Get user's information. Email field and broadcast opt-in status require authentication as staff member or API key.
+      Prevent staff assigment flag requires authentication as senior staff.",
      *     produces={"application/json"}, tags={"user"},
      * @SWG\Parameter(name="cid",in="path",required=true,type="string",description="Cert ID"),
      * @SWG\Response(

--- a/app/TMUFacility.php
+++ b/app/TMUFacility.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TMUFacility extends Model
+{
+    protected $table = 'tmu_facilities';
+
+    public function tmuNotices()
+    {
+        return $this->hasMany(TMUNotice::class, 'tmu_facility_id');
+    }
+}

--- a/app/TMUFacility.php
+++ b/app/TMUFacility.php
@@ -8,6 +8,8 @@ class TMUFacility extends Model
 {
     protected $table = 'tmu_facilities';
 
+    public $incrementing = false;
+
     public function tmuNotices()
     {
         return $this->hasMany(TMUNotice::class, 'tmu_facility_id');

--- a/app/TMUNotice.php
+++ b/app/TMUNotice.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class TMUNotice extends Model
 {
-    public $timestamps = ['created_at', 'updated_at', 'expire_date'];
+    public $timestamps = ['created_at', 'updated_at', 'expire_date', 'start_date'];
     protected $guarded = [];
     protected $table = 'tmu_notices';
 

--- a/app/TMUNotice.php
+++ b/app/TMUNotice.php
@@ -6,7 +6,7 @@ use Illuminate\Database\Eloquent\Model;
 
 class TMUNotice extends Model
 {
-    public $timestamps = ['created_at', 'updated_at', 'expire_date', 'start_date'];
+    public $dates = ['created_at', 'updated_at', 'expire_date', 'start_date'];
     protected $guarded = [];
     protected $table = 'tmu_notices';
 

--- a/app/TMUNotice.php
+++ b/app/TMUNotice.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace App;
+
+use Illuminate\Database\Eloquent\Model;
+
+class TMUNotice extends Model
+{
+    public $timestamps = ['created_at', 'updated_at', 'expire_date'];
+    protected $guarded = [];
+    protected $table = 'tmu_notices';
+
+    public function tmuFacility()
+    {
+        return $this->belongsTo(TMUFacility::class);
+    }
+}

--- a/database/migrations/2019_07_17_225117_create_tmu_notices_table.php
+++ b/database/migrations/2019_07_17_225117_create_tmu_notices_table.php
@@ -16,7 +16,7 @@ class CreateTmuNoticesTable extends Migration
         Schema::create('tmu_notices', function (Blueprint $table) {
             $table->increments('id');
             $table->string('tmu_facility_id');
-            $table->smallInteger('priority'); // 0 => Low; 1 => Standard; 2 => Urgent
+            $table->smallInteger('priority'); // 1 => Low; 2 => Standard; 3 => Urgent
             $table->string('message');
             $table->dateTime('start_date');
             $table->dateTime('expire_date')->nullable();

--- a/database/migrations/2019_07_17_225117_create_tmu_notices_table.php
+++ b/database/migrations/2019_07_17_225117_create_tmu_notices_table.php
@@ -18,7 +18,8 @@ class CreateTmuNoticesTable extends Migration
             $table->string('tmu_facility_id');
             $table->smallInteger('priority'); // 0 => Low; 1 => Standard; 2 => Urgent
             $table->string('message');
-            $table->dateTime('expire_date');
+            $table->dateTime('start_date');
+            $table->dateTime('expire_date')->nullable();
             $table->timestamps();
         });
     }

--- a/database/migrations/2019_07_17_225117_create_tmu_notices_table.php
+++ b/database/migrations/2019_07_17_225117_create_tmu_notices_table.php
@@ -15,7 +15,7 @@ class CreateTmuNoticesTable extends Migration
     {
         Schema::create('tmu_notices', function (Blueprint $table) {
             $table->increments('id');
-            $table->integer('tmu_facility_id');
+            $table->string('tmu_facility_id');
             $table->smallInteger('priority'); // 0 => Low; 1 => Standard; 2 => Urgent
             $table->string('message');
             $table->dateTime('expire_date');

--- a/database/migrations/2019_07_17_225117_create_tmu_notices_table.php
+++ b/database/migrations/2019_07_17_225117_create_tmu_notices_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateTmuNoticesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('tmu_notices', function (Blueprint $table) {
+            $table->increments('id');
+            $table->integer('tmu_facility_id');
+            $table->smallInteger('priority'); // 0 => Low; 1 => Standard; 2 => Urgent
+            $table->string('message');
+            $table->dateTime('expire_date');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('tmu_notices');
+    }
+}

--- a/public/.htaccess
+++ b/public/.htaccess
@@ -6,9 +6,9 @@
     RewriteEngine On
 
     # Redirect Trailing Slashes If Not A Folder...
-    RewriteCond %{REQUEST_FILENAME} !-d
-    RewriteCond %{REQUEST_URI} (.+)/$
-    RewriteRule ^ %1 [L,R=301]
+    #RewriteCond %{REQUEST_FILENAME} !-d
+    #RewriteCond %{REQUEST_URI} (.+)/$
+    #RewriteRule ^ %1 [L,R=301]
 
     # Handle Front Controller...
     RewriteCond %{REQUEST_FILENAME} !-d

--- a/routes/api-v2.php
+++ b/routes/api-v2.php
@@ -241,6 +241,7 @@ Route::group(['prefix' => '/user'], function () {
  * TMU functions
  */
 Route::group(['prefix' => '/tmu'], function () {
+    Route::get('notice/{notice}', 'TMUController@getNotice');
     Route::group(['prefix' => '/notices'], function () {
         Route::get('{tmufacid?}', 'TMUController@getNotices');
         Route::group(['middleware' => 'semiprivate'], function() {

--- a/routes/api-v2.php
+++ b/routes/api-v2.php
@@ -241,12 +241,14 @@ Route::group(['prefix' => '/user'], function () {
  * TMU functions
  */
 Route::group(['prefix' => '/tmu'], function () {
-    Route::get('notice/{notice}', 'TMUController@getNotice');
+    Route::group(['prefix' => '/notice'], function () {
+        Route::get('{notice}', 'TMUController@getNotice');
+        Route::put('{notice}', 'TMUController@editNotice');
+        Route::delete('{notice}', 'TMUController@removeNotice');
+    });
     Route::group(['prefix' => '/notices'], function () {
-        Route::get('{tmufacid?}', 'TMUController@getNotices');
-        Route::group(['middleware' => 'semiprivate'], function() {
-            Route::delete('{noticeId}', 'TMUController@removeNotice');
-            Route::put('{noticeId}', 'TMUController@editNotice');
+        Route::get('{facility?}', 'TMUController@getNotices');
+        Route::group(['middleware' => 'semiprivate'], function () {
             Route::post('/', 'TMUController@addNotice');
         });
     });

--- a/routes/api-v2.php
+++ b/routes/api-v2.php
@@ -133,7 +133,7 @@ Route::group(['prefix' => '/infrastructure', 'middleware' => ['auth:web,jwt', 'p
 
 Route::group(['prefix' => '/solo'], function () {
     Route::get('/', 'SoloController@getIndex');
-    Route::group(['middleware' => 'semiprivate'], function() {
+    Route::group(['middleware' => 'semiprivate'], function () {
         Route::post('/', 'SoloController@postSolo');
         Route::delete('/', 'SoloController@deleteSolo');
     });
@@ -233,5 +233,18 @@ Route::group(['prefix' => '/user'], function () {
 
         Route::get('/{cid}/log', 'UserController@getActionLog')->where('cid', '[0-9]+');
         Route::post('/{cid}/log', 'UserController@postActionLog')->where('cid', '[0-9]+');
+    });
+});
+
+/******************************************************************************************
+ * /tmu
+ * TMU functions
+ */
+Route::group(['prefix' => '/tmu'], function () {
+    Route::group(['prefix' => '/notices'], function () {
+        Route::get('{tmufacid?}', 'TMUController@getNotices');
+        Route::delete('{noticeId}', 'TMUController@removeNotice');
+        Route::put('{noticeId}', 'TMUController@editNotice');
+        Route::post('/', 'TMUController@addNotice');
     });
 });

--- a/routes/api-v2.php
+++ b/routes/api-v2.php
@@ -243,8 +243,10 @@ Route::group(['prefix' => '/user'], function () {
 Route::group(['prefix' => '/tmu'], function () {
     Route::group(['prefix' => '/notices'], function () {
         Route::get('{tmufacid?}', 'TMUController@getNotices');
-        Route::delete('{noticeId}', 'TMUController@removeNotice');
-        Route::put('{noticeId}', 'TMUController@editNotice');
-        Route::post('/', 'TMUController@addNotice');
+        Route::group(['middleware' => 'semiprivate'], function() {
+            Route::delete('{noticeId}', 'TMUController@removeNotice');
+            Route::put('{noticeId}', 'TMUController@editNotice');
+            Route::post('/', 'TMUController@addNotice');
+        });
     });
 });


### PR DESCRIPTION
This update adds TMU Notices. Similar to the FAA OIS, TMU Notices allow facilities to communicate ground stops, delays, routing, etc. to other facilities. This is especially useful during events or busy periods.

Additionally, the `GET /facility/{id}/transfers` endpoint to get pending transfers has changed. It now returns the user's origin facility and their email (with proper authentication). The `name` property has also been split into `fname` and `lname`. See API documentation for more information.

Solo certification endpoints should now be working.