### PR TITLE
Visiting Roster

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ app/Console/Commands/test.php
 _ide_helper.php
 _ide_helper_models.php
 .phpstorm.meta.php
+build.modified.sh

--- a/app/Classes/OAuth/VatsimConnect.php
+++ b/app/Classes/OAuth/VatsimConnect.php
@@ -84,7 +84,7 @@ class VatsimConnect extends GenericProvider
 
         if (!$code/* || !$state || $state !== $request->get('oauthstate')*/) {
             $request->session()->forget("return");
-            $error = "Invalid response from VATSIM, please try again. If this error persists, contact VATUSA6.";
+            $error = "Invalid response from VATSIM, please try again. If this error persists, contact VATUSA12.";
 
             return $isULS ? response($error, 401) : redirect(env('SSO_RETURN_HOME_ERROR'))->with('error',
                 $error);
@@ -99,7 +99,7 @@ class VatsimConnect extends GenericProvider
                 ]);
             } catch (IdentityProviderException $e) {
                 $request->session()->forget("return");
-                $error = "An error occurred while logging in with VATSIM, please try again. If this error persists, contact VATUSA6.";
+                $error = "An error occurred while logging in with VATSIM, please try again. If this error persists, contact VATUSA12.";
 
                 return $isULS ? response($error, 401) : redirect(env('SSO_RETURN_HOME_ERROR'))->with('error',
                     $error);
@@ -112,7 +112,7 @@ class VatsimConnect extends GenericProvider
                 $resource->data->personal->name_first, $resource->data->personal->name_last) || $resource->data->oauth->token_valid != true) {
             $request->session()->forget("return");
             $error = "Insufficient user data provided. In order to login, you must allow us to continuously recieve all of your VATSIM data: full name, email, and rating information.
-             Please try again. If this error persists, contact VATUSA6.";
+             Please try again. If this error persists, contact VATUSA12.";
 
             return $isULS ? response($error, 401) : redirect(env('SSO_RETURN_HOME_ERROR'))->with('error',
                 $error);

--- a/app/Facility.php
+++ b/app/Facility.php
@@ -35,6 +35,13 @@ class Facility extends Model
         return $this->hasMany('App\User', 'facility', 'id')->orderBy('lname', 'ASC');
     }
 
+    public function visitors()
+    {
+        return User::whereHas('visits', function($q){
+            $q->where('facility', $this->id)->where('active', 1);
+        })->get();
+    }
+
     public function atm()
     {
         return $this->hasOne('App\User', 'cid', 'atm')->first();

--- a/app/Facility.php
+++ b/app/Facility.php
@@ -38,7 +38,7 @@ class Facility extends Model
     public function visitors()
     {
         return User::whereHas('visits', function($q) {
-            $q->where('facility', $this->id)->where('active', 1);
+            $q->where('facility', $this->id);
         })->get();
     }
 

--- a/app/Facility.php
+++ b/app/Facility.php
@@ -37,7 +37,7 @@ class Facility extends Model
 
     public function visitors()
     {
-        return User::whereHas('visits', function($q){
+        return User::whereHas('visits', function($q) {
             $q->where('facility', $this->id)->where('active', 1);
         })->get();
     }

--- a/app/Http/Controllers/API/v2/FacilityController.php
+++ b/app/Http/Controllers/API/v2/FacilityController.php
@@ -563,11 +563,36 @@ class FacilityController extends APIController
      *         response="200",
      *         description="OK",
      *         @SWG\Schema(
-     *             type="array",
-     *             @SWG\Items(
-     *                 ref="#/definitions/User",
-     *             ),
-     *         ),
+     *             type="object",
+     *             @SWG\Property(property="cid", type="integer"),
+     *             @SWG\Property(property="fname", type="string", description="First name"),
+     *             @SWG\Property(property="lname", type="string", description="Last name"),
+     *             @SWG\Property(property="email", type="string", description="Email address of user, will be null if API Key or necessary roles are not available (ATM, DATM, TA, WM, INS)"),
+     *             @SWG\Property(property="facility", type="string", description="Facility ID"),
+     *             @SWG\Property(property="rating", type="integer", description="Rating based off array where 1=OBS, S1, S2, S3, C1, C2, C3, I1, I2, I3, SUP, ADM"),
+     *             @SWG\Property(property="rating_short", type="string", description="String representation of rating"),
+     *             @SWG\Property(property="created_at", type="string", description="Date added to database"),
+     *             @SWG\Property(property="updated_at", type="string"),
+     *             @SWG\Property(property="flag_needbasic", type="integer", description="1 needs basic exam"),
+     *             @SWG\Property(property="flag_xferOverride", type="integer", description="Has approved transfer override"),
+     *             @SWG\Property(property="flag_broadcastOptedIn", type="integer", description="Has opted in to receiving broadcast emails"),
+     *             @SWG\Property(property="flag_preventStaffAssign", type="integer", description="Ineligible for staff role assignment"),
+     *             @SWG\Property(property="facility_join", type="string", description="Date joined facility (YYYY-mm-dd hh:mm:ss)"),
+     *             @SWG\Property(property="promotion_eligible", type="boolean", description="Is member eligible for promotion?"),
+     *             @SWG\Property(property="transfer_eligible", type="boolean", description="Is member is eligible for transfer?"),
+     *             @SWG\Property(property="last_promotion", type="string", description="Date last promoted"),
+     *             @SWG\Property(property="flag_homecontroller", type="boolean", description="1-Belongs to VATUSA"),
+     *             @SWG\Property(property="lastactivity", type="string", description="Date last seen on website"),
+     *             @SWG\Property(property="isMentor", type="boolean", description="Has Mentor role"),
+     *             @SWG\Property(property="isSupIns", type="boolean", description="Is a SUP and has INS role"),
+     *             @SWG\Property(property="membership", type="string", description="'Home' or 'visit' depending on facility membership."),
+     *             @SWG\Property(property="roles", type="array",
+     *                 @SWG\Items(type="object",
+     *                     @SWG\Property(property="facility", type="string"),
+     *                     @SWG\Property(property="role", type="string")
+     *                 )
+     *             )
+     *         )
      *     )
      * )
      */
@@ -631,12 +656,21 @@ class FacilityController extends APIController
                 $member->roles->where("facility", $id)
                     ->where("role", "INS")->count() > 0;
 
-            // Last promotion date
+            //Last promotion date
             $last_promotion = $member->lastPromotion();
             if ($last_promotion) {
                 $rosterArr[$i]['last_promotion'] = $last_promotion->created_at;
             } else {
                 $rosterArr[$i]['last_promotion'] = null;
+            }
+
+            //Membership
+            if ($member->facility == $id) {
+                $rosterArr[$i]['membership'] = 'home';
+            } else {
+                $rosterArr[$i]['membership'] = 'visit';
+                $rosterArr[$i]['facility_join'] = Visit::where('facility', $id)
+                                                        ->where('cid', $member->cid)->first()->updated_at;
             }
 
             $i++;

--- a/app/Http/Controllers/API/v2/FacilityController.php
+++ b/app/Http/Controllers/API/v2/FacilityController.php
@@ -779,6 +779,9 @@ class FacilityController extends APIController
             $visitor->facility = $id;
             $visitor->active = 1;
             $visitor->save();
+
+            log_action($user->cid, "User added to $facility->id visiting roster by " . \Auth::user()->fullname()
+                . " (" . \Auth::user()->cid . ")");
         }
 
         return response()->ok();
@@ -860,9 +863,9 @@ class FacilityController extends APIController
 
         // Checks if user with specified cid exists
         $user = User::where('cid', $cid)->first();
-        if (!$user || $user->facility != $facility->id) {
+        if (!$user) {
             return response()->api(
-                generate_error("User not found or not in facility"), 404
+                generate_error("User not found."), 404
             );
         }
 
@@ -881,6 +884,9 @@ class FacilityController extends APIController
 
         $visit->active = 0;
         $visit->save();
+
+        log_action($user->cid, "User removed from $facility->id visiting roster by " . \Auth::user()->fullname()
+            . ": " . $request->input("reason"));
 
         return response()->ok();
     }

--- a/app/Http/Controllers/API/v2/FacilityController.php
+++ b/app/Http/Controllers/API/v2/FacilityController.php
@@ -12,6 +12,7 @@ use App\TMUFacility;
 use App\TMUNotice;
 use App\Transfer;
 use App\User;
+use App\Promotion;
 use App\Visit;
 use Illuminate\Http\Request;
 use App\Facility;
@@ -629,6 +630,14 @@ class FacilityController extends APIController
             $rosterArr[$i]['isSupIns'] = $roster[$i]['rating_short'] === "SUP" &&
                 $member->roles->where("facility", $id)
                     ->where("role", "INS")->count() > 0;
+
+            // Last promotion date
+            $promotion = Promotion::where('cid', $member->cid)->latest()->first();
+            if ($promotion) {
+                $rosterArr[$i]['last_promotion'] = $promotion->created_at;
+            } else {
+                $rosterArr[$i]['last_promotion'] = null;
+            }
 
             $i++;
         }

--- a/app/Http/Controllers/API/v2/FacilityController.php
+++ b/app/Http/Controllers/API/v2/FacilityController.php
@@ -632,9 +632,9 @@ class FacilityController extends APIController
                     ->where("role", "INS")->count() > 0;
 
             // Last promotion date
-            $promotion = Promotion::where('cid', $member->cid)->latest()->first();
-            if ($promotion) {
-                $rosterArr[$i]['last_promotion'] = $promotion->created_at;
+            $last_promotion = $member->lastPromotion();
+            if ($last_promotion) {
+                $rosterArr[$i]['last_promotion'] = $last_promotion->created_at;
             } else {
                 $rosterArr[$i]['last_promotion'] = null;
             }

--- a/app/Http/Controllers/API/v2/FacilityController.php
+++ b/app/Http/Controllers/API/v2/FacilityController.php
@@ -644,7 +644,7 @@ class FacilityController extends APIController
      * @return \Illuminate\Http\JsonResponse
      *
      * @SWG\Post(
-     *     path="/facility/{id}/manageVisitor/{cid}",
+     *     path="/facility/{id}/roster/manageVisitor/{cid}",
      *     summary="Add member to visiting roster. [Auth]",
      *     description="Add member to visiting roster.  JWT or Session Cookie required (required role: ATM,
     DATM, VATUSA STAFF)",
@@ -749,7 +749,7 @@ class FacilityController extends APIController
      * @return \Illuminate\Http\JsonResponse
      *
      * @SWG\Delete(
-     *     path="/facility/{id}/manageVisitor/{cid}",
+     *     path="/facility/{id}/roster/manageVisitor/{cid}",
      *     summary="Delete member from visiting roster. [Auth]",
      *     description="Delete member from visiting roster.  JWT or Session Cookie required (required role: ATM,
     DATM, VATUSA STAFF)",

--- a/app/Http/Controllers/API/v2/TrainingController.php
+++ b/app/Http/Controllers/API/v2/TrainingController.php
@@ -141,16 +141,7 @@ class TrainingController extends Controller
         // GET /user/1275302/training/records
         if ($this->canView($request, null, $user)) {
             return response()->api(TrainingRecord::where('student_id',
-                $user->cid)->with('facility:id,name')->get()->filter(function ($record) use ($user, $request) {
-                if (Auth::user() && $user->facility !== Auth::user()->facility || $request->has('apikey') && $user->visits()->where('facility',
-                        Facility::where("apikey", $request->apikey)
-                            ->orWhere("api_sandbox_key", $request->apikey)->first()->id)->exists()) {
-                    //Visitor
-                    return $record->ots_status > 0;
-                } else {
-                    return true;
-                }
-            })->toArray());
+                $user->cid)->with('facility:id,name')->get()->toArray());
         }
 
         return response()->forbidden();
@@ -1134,7 +1125,7 @@ class TrainingController extends Controller
         if ($request->has('apikey') && $keyFac) {
             if ($record) {
                 $apiKeyVisitor = $record->student->visits()->where('facility',
-                        $keyFac->id)->exists() && $record->ots_status;
+                        $keyFac->id)->exists();
             }
             if ($user) {
                 $apiKeyVisitor = $user->visits()->where('facility',
@@ -1142,7 +1133,7 @@ class TrainingController extends Controller
             }
         }
         $visitor = Auth::user() && RoleHelper::isTrainingStaff(Auth::user()->cid,
-                true) && ($record && $record->ots_status && $record->student->visits()->where('facility',
+                true) && ($record && $record->student->visits()->where('facility',
                     Auth::user()->facility)->exists() || $user && $user->visits()->where('facility',
                     Auth::user()->facility)->exists());
 

--- a/app/Http/Controllers/API/v2/UserController.php
+++ b/app/Http/Controllers/API/v2/UserController.php
@@ -98,6 +98,8 @@ class UserController extends APIController
             }
 
             $data['visiting_facilities'] = $vis_array;
+        } else {
+            $data['visiting_facilities'] = null;
         }
 
         //Is Mentor
@@ -1177,8 +1179,7 @@ class UserController extends APIController
      *                 @SWG\Property(property="lname", type="string"),
      *             )
      *         ),
-     *         examples={"application/json":{
-     *         }}
+     *         examples={"application/json":{"0":{"cid":1391803,"fname":"Michael","lname":"Romashov"},"1":{"cid":1391802,"fname":"Sankara","lname":"Narayanan "}}}
      *     )
      * )
      */
@@ -1237,8 +1238,7 @@ class UserController extends APIController
      *                 @SWG\Property(property="lname", type="string"),
      *             )
      *         ),
-     *         examples={"application/json":{
-     *         }}
+     *         examples={"application/json":{"0":{"cid":1459055,"fname":"Aidan","lname":"Deschene"},"1":{"cid":1263769,"fname":"Austin","lname":"Tedesco"},"2":{"cid":919571,"fname":"Matthew","lname":"Tedesco"},"3":{"cid":1202101,"fname":"Mike","lname":"Tedesco"}}}
      *     )
      * )
      */

--- a/app/Http/Controllers/API/v2/UserController.php
+++ b/app/Http/Controllers/API/v2/UserController.php
@@ -80,24 +80,7 @@ class UserController extends APIController
 
         if ($isFacStaff || $isSeniorStaff || AuthHelper::validApiKeyv2($request->input('apikey', null))) {
             // Get Facilties CID is Visiting
-            $vis_query = $user->visits()
-                ->pluck('facility');
-
-            $vis_array = [];
-
-            foreach ($vis_query as &$fac) {
-                $query = Facility::where('id', $fac);
-
-                $array = [
-                    "id" => $fac,
-                    "name" => $query->value('name'),
-                    "region" => $query->value('region')
-                ];
-
-                $vis_array[] = $array;
-            }
-
-            $data['visiting_facilities'] = $vis_array;
+            $data['visiting_facilities'] = $user->visits->toArray();
         } else {
             $data['visiting_facilities'] = null;
         }

--- a/app/Http/Controllers/API/v2/UserController.php
+++ b/app/Http/Controllers/API/v2/UserController.php
@@ -1119,4 +1119,124 @@ class UserController extends APIController
 
         return response()->api($results);
     }
+
+    /**
+     * @param $partialCid
+     *
+     * @return array|string
+     *
+     * @SWG\Get(
+     *     path="/user/filtercid/(partialCid)",
+     *     summary="Filter users by partial CID.",
+     *     description="Get an array of users matching a given partial CID.",
+     *     produces={"application/json"}, tags={"user"},
+     * @SWG\Parameter(name="partialCid", in="path", required=true, type="integer", description="Partial CERT ID"),
+     * @SWG\Response(
+     *         response="404",
+     *         description="Not Found",
+     *         @SWG\Schema(ref="#/definitions/error"),
+     *         examples={"application/json":{"status"="error","msg"="No matching users found."}},
+     *     ),
+     * @SWG\Response(
+     *         response="412",
+     *         description="Precondition Failed (>= 4 digits)",
+     *         @SWG\Schema(ref="#/definitions/error"),
+     *         examples={"application/json":{"status"="error","msg"="Partial CID must be at least 4 digits."}},
+     *     ),
+     * @SWG\Response(
+     *         response="200",
+     *         description="OK",
+     *         @SWG\Schema(
+     *             type="array",
+     *             @SWG\Items(
+     *                 type="object",
+     *                 @SWG\Property(property="cid", type="integer"),
+     *                 @SWG\Property(property="fname", type="string"),
+     *                 @SWG\Property(property="lname", type="string"),
+     *             )
+     *         ),
+     *         examples={"application/json":{
+     *         }}
+     *     )
+     * )
+     */
+    public function filterUsersCid($partialCid)
+    {
+        if (strlen($partialCid) < 4) {
+            return response()->api(generate_error("Partial CID must be at least 4 digits."), 412);
+        }
+
+        $matches = User::where('cid', 'like', "%$partialCid%")->orderBy('fname', 'asc')->get();
+
+        if (!$matches) {
+            return response()->api(generate_error("No matching users found.", 404));
+        }
+
+        $return = [];
+        foreach ($matches as $match) {
+            $return[] = ['cid' => $match->cid, 'fname' => $match->fname, 'lname' => $match->lname];
+        }
+
+        return response()->api($return);
+    }
+
+    /**
+     * @param $partialLName
+     *
+     * @return array|string
+     *
+     * @SWG\Get(
+     *     path="/user/filterlname/(partialLName)",
+     *     summary="Filter users by partial last name.",
+     *     description="Get an array of users matching a given partial last name.",
+     *     produces={"application/json"}, tags={"user"},
+     * @SWG\Parameter(name="partialLName", in="path", required=true, type="string", description="Partial Last Name"),
+     * @SWG\Response(
+     *         response="404",
+     *         description="Not Found",
+     *         @SWG\Schema(ref="#/definitions/error"),
+     *         examples={"application/json":{"status"="error","msg"="No matching users found."}},
+     *     ),
+     * @SWG\Response(
+     *         response="412",
+     *         description="Precondition Failed (>= 4 letters)",
+     *         @SWG\Schema(ref="#/definitions/error"),
+     *         examples={"application/json":{"status"="error","msg"="Partial last name must be at least 4 letters."}},
+     *     ),
+     * @SWG\Response(
+     *         response="200",
+     *         description="OK",
+     *         @SWG\Schema(
+     *             type="array",
+     *             @SWG\Items(
+     *                 type="object",
+     *                 @SWG\Property(property="cid", type="integer"),
+     *                 @SWG\Property(property="fname", type="string"),
+     *                 @SWG\Property(property="lname", type="string"),
+     *             )
+     *         ),
+     *         examples={"application/json":{
+     *         }}
+     *     )
+     * )
+     */
+    public function filterUsersLName($partialLName)
+    {
+        if (strlen($partialLName) < 4) {
+            return response()->api(generate_error("Partial last name must be at least 4 letters."), 412);
+        }
+
+        $matches = User::where('lname', 'like', "%$partialLName%")->orderBy('fname', 'asc')->get();
+
+        if (!$matches) {
+            return response()->api(generate_error("No matching users found.", 404));
+        }
+
+        $return = [];
+        foreach ($matches as $match) {
+            $return[] = ['cid' => $match->cid, 'fname' => $match->fname, 'lname' => $match->lname];
+        }
+
+        return response()->api($return);
+    }
 }

--- a/app/Http/Controllers/API/v2/UserController.php
+++ b/app/Http/Controllers/API/v2/UserController.php
@@ -88,6 +88,9 @@ class UserController extends APIController
                 ->where("cid", $user->cid)
                 ->where("role", "INS")->exists();
 
+        //Last Promotion
+        $data['last_promotion'] = $user->lastPromotion()->created_at;
+
         return response()->api($data);
     }
 

--- a/app/Http/Controllers/Login/SSOController.php
+++ b/app/Http/Controllers/Login/SSOController.php
@@ -135,7 +135,7 @@ class SSOController extends Controller
                 $signature = ULSHelper::base64url_encode($signature);
                 $data = file_get_contents("https://forums.vatusa.net/api.php?register=1&data=$token&signature=$signature");
                 if ($data != "OK") {
-                    $error = "Unable to create forum data. Please try again later or contact VATUSA6.";
+                    $error = "Unable to create forum data. Please try again later or contact VATUSA12.";
 
                     return $isULS ? response($error, 401) : redirect(env('SSO_RETURN_HOME_ERROR'))->with('error', $error);
 

--- a/app/Http/Controllers/Login/SSOController.php
+++ b/app/Http/Controllers/Login/SSOController.php
@@ -172,10 +172,10 @@ class SSOController extends Controller
             if (!$member->flag_homecontroller && $user->vatsim->division->id == "USA") {
                 //User is rejoining
                 $transfers = Transfer::where('cid', $member->cid)->where('actiontext', "Left division")
-                    ->where('created_at', '>=', Carbon::now()->subDays(90))
+                    ->where('created_at', '>=', Carbon::now()->subHours(48))
                     ->orderBy('created_at', 'DESC');
                 if ($transfers->count()) {
-                    //Within last 90 days
+                    //Within last 48 hours
                     $t = $transfers->first();
                     $member->addToFacility($t->from);
 
@@ -190,7 +190,7 @@ class SSOController extends Controller
 
                     $log = new Action();
                     $log->to = $member->cid;
-                    $log->log = "Rejoined division within 90 days, facility set to " . $member->facility;
+                    $log->log = "Rejoined division within 48 hours, facility set to " . $member->facility;
                     $log->save();
                 } elseif (Transfer::where('cid', $member->cid)->where('actiontext', "Left division")
                     ->where('created_at', '<=', Carbon::now()->subMonths(6))
@@ -215,7 +215,7 @@ class SSOController extends Controller
                     $log->log = "Rejoined division after more than 6 months, facility set to ZAE";
                     $log->save();
                 } else {
-                    //Within last 6 months but more than 90 days (or xfr doesn't exist for some reason)
+                    //Within last 6 months but more than 48 hours (or xfr doesn't exist for some reason)
                     $member->facility = "ZAE";
                     $member->facility_join = Carbon::now();
                     $member->flag_needbasic = !$transfers->exists();
@@ -231,7 +231,7 @@ class SSOController extends Controller
 
                     $log = new Action();
                     $log->to = $member->cid;
-                    $log->log = "Rejoined division within 6 months and more than 90 days, facility set to ZAE";
+                    $log->log = "Rejoined division within 6 months and more than 48 hours, facility set to ZAE";
                     $log->save();
                 }
                 // Now let us check to see if they have ever been in a facility.. if not, we need to override the need basic flag.

--- a/app/SurveyAssignment.php
+++ b/app/SurveyAssignment.php
@@ -71,7 +71,7 @@ class SurveyAssignment extends Model
             fputs($fh, $data);
             fclose($fh);
 
-            \Mail::to($user)->cc("vatusa6@vatusa.net")->send(new \App\Mail\SurveyAssignment($user, $survey, $a));
+            \Mail::to($user)->cc("vatusa12@vatusa.net")->send(new \App\Mail\SurveyAssignment($user, $survey, $a));
             unlink($template_file);
         }
         return $a;

--- a/app/User.php
+++ b/app/User.php
@@ -36,6 +36,8 @@ use League\OAuth2\Client\Token\AccessToken;
  *                                                       assignment"),
  *     @SWG\Property(property="facility_join", type="string", description="Date joined facility (YYYY-mm-dd
  *                                             hh:mm:ss)"),
+ *     @SWG\Property(property="last_promotion", type="string", description="Date last promoted (YYYY-mm-dd
+ *                                             hh:mm:ss)"),
  *     @SWG\Property(property="promotion_eligible", type="boolean", description="Is member eligible for promotion?"),
  *     @SWG\Property(property="transfer_eligible", type="boolean", description="Is member is eligible for transfer?"),
  *     @SWG\Property(property="flag_homecontroller", type="integer", description="1-Belongs to VATUSA"),

--- a/app/User.php
+++ b/app/User.php
@@ -45,6 +45,13 @@ use League\OAuth2\Client\Token\AccessToken;
  *             @SWG\Property(property="facility", type="string"),
  *             @SWG\Property(property="role", type="string")
  *         )
+ *     ),
+ *     @SWG\Property(property="visiting_facilities", type="array",
+ *         @SWG\Items(type="object",
+ *             @SWG\Property(property="id", type="string"),
+ *             @SWG\Property(property="name", type="string"),
+ *             @SWG\Property(property="region", type="integer")
+ *         )
  *     )
  * )
  */

--- a/app/User.php
+++ b/app/User.php
@@ -105,6 +105,11 @@ class User extends Model implements AuthenticatableContract, JWTSubject
         return $this->belongsTo(Facility::class, 'facility')->first();
     }
 
+    public function visits()
+    {
+        return $this->hasMany(Visit::class, 'cid', 'cid');
+    }
+
     /**
      * @return bool
      */

--- a/app/User.php
+++ b/app/User.php
@@ -20,24 +20,18 @@ use League\OAuth2\Client\Token\AccessToken;
  *     @SWG\Property(property="cid", type="integer"),
  *     @SWG\Property(property="fname", type="string", description="First name"),
  *     @SWG\Property(property="lname", type="string", description="Last name"),
- *     @SWG\Property(property="email", type="string", description="Email address of user, will be null if API Key or
- *                                     necessary roles are not available (ATM, DATM, TA, WM, INS)"),
+ *     @SWG\Property(property="email", type="string", description="Email address of user, will be null if API Key or necessary roles are not available (ATM, DATM, TA, WM, INS)"),
  *     @SWG\Property(property="facility", type="string", description="Facility ID"),
- *     @SWG\Property(property="rating", type="integer", description="Rating based off array where 1=OBS, S1, S2, S3,
- *                                      C1, C2, C3, I1, I2, I3, SUP, ADM"),
+ *     @SWG\Property(property="rating", type="integer", description="Rating based off array where 1=OBS, S1, S2, S3, C1, C2, C3, I1, I2, I3, SUP, ADM"),
  *     @SWG\Property(property="rating_short", type="string", description="String representation of rating"),
  *     @SWG\Property(property="created_at", type="string", description="Date added to database"),
  *     @SWG\Property(property="updated_at", type="string"),
  *     @SWG\Property(property="flag_needbasic", type="integer", description="1 needs basic exam"),
  *     @SWG\Property(property="flag_xferOverride", type="integer", description="Has approved transfer override"),
- *     @SWG\Property(property="flag_broadcastOptedIn", type="integer", description="Has opted in to receiving broadcast
- *                                                     emails"),
- *     @SWG\Property(property="flag_preventStaffAssign", type="integer", description="Ineligible for staff role
- *                                                       assignment"),
- *     @SWG\Property(property="facility_join", type="string", description="Date joined facility (YYYY-mm-dd
- *                                             hh:mm:ss)"),
- *     @SWG\Property(property="last_promotion", type="string", description="Date last promoted (YYYY-mm-dd
- *                                             hh:mm:ss)"),
+ *     @SWG\Property(property="flag_broadcastOptedIn", type="integer", description="Has opted in to receiving broadcast emails"),
+ *     @SWG\Property(property="flag_preventStaffAssign", type="integer", description="Ineligible for staff role assignment"),
+ *     @SWG\Property(property="facility_join", type="string", description="Date joined facility (YYYY-mm-dd hh:mm:ss)"),
+ *     @SWG\Property(property="last_promotion", type="string", description="Date last promoted (YYYY-mm-dd hh:mm:ss)"),
  *     @SWG\Property(property="promotion_eligible", type="boolean", description="Is member eligible for promotion?"),
  *     @SWG\Property(property="transfer_eligible", type="boolean", description="Is member is eligible for transfer?"),
  *     @SWG\Property(property="flag_homecontroller", type="integer", description="1-Belongs to VATUSA"),

--- a/app/User.php
+++ b/app/User.php
@@ -33,19 +33,9 @@ use League\OAuth2\Client\Token\AccessToken;
  *     @SWG\Property(property="flag_broadcastOptedIn", type="integer", description="Has opted in to receiving broadcast emails"),
  *     @SWG\Property(property="flag_preventStaffAssign", type="integer", description="Ineligible for staff role assignment"),
  *     @SWG\Property(property="facility_join", type="string", description="Date joined facility (YYYY-mm-dd hh:mm:ss)"),
- *     @SWG\Property(property="last_promotion", type="string", description="Date last promoted (YYYY-mm-dd hh:mm:ss)"),
- *     @SWG\Property(property="flag_needbasic", type="boolean", description="1 needs basic exam"),
- *     @SWG\Property(property="flag_xferOverride", type="boolean", description="Has approved transfer override"),
- *     @SWG\Property(property="flag_broadcastOptedIn", type="boolean", description="Has opted in to receiving broadcast emails"),
- *     @SWG\Property(property="flag_preventStaffAssign", type="boolean", description="Ineligible for staff role assignment"),
- *     @SWG\Property(property="facility_join", type="string", description="Date joined facility (YYYY-mm-dd hh:mm:ss)"),
- *     @SWG\Property(property="flag_needbasic", type="boolean", description="1 needs basic exam"),
- *     @SWG\Property(property="flag_xferOverride", type="boolean", description="Has approved transfer override"),
- *     @SWG\Property(property="flag_broadcastOptedIn", type="boolean", description="Has opted in to receiving broadcast emails"),
- *     @SWG\Property(property="flag_preventStaffAssign", type="boolean", description="Ineligible for staff role assignment"),
- *     @SWG\Property(property="facility_join", type="string", description="Date joined facility (YYYY-mm-dd hh:mm:ss)"),
  *     @SWG\Property(property="promotion_eligible", type="boolean", description="Is member eligible for promotion?"),
  *     @SWG\Property(property="transfer_eligible", type="boolean", description="Is member is eligible for transfer?"),
+ *     @SWG\Property(property="last_promotion", type="string", description="Date last promoted"),
  *     @SWG\Property(property="flag_homecontroller", type="boolean", description="1-Belongs to VATUSA"),
  *     @SWG\Property(property="lastactivity", type="string", description="Date last seen on website"),
  *     @SWG\Property(property="isMentor", type="boolean", description="Has Mentor role"),
@@ -144,6 +134,12 @@ class User extends Model implements AuthenticatableContract, JWTSubject
     {
         return $this->hasMany(Visit::class, 'cid', 'cid');
     }
+
+    public function lastPromotion()
+    {
+        return $this->hasMany(Promotion::class, 'cid', 'cid')->latest()->first();
+    }
+
     /**
      * @return bool
      */

--- a/app/Visit.php
+++ b/app/Visit.php
@@ -1,0 +1,25 @@
+<?php
+namespace App;
+
+/**
+ * Class Visit
+ * @package App
+ *
+ * @SWG\Definition(
+ *     type="object",
+ *     @SWG\Property(property="id", type="integer"),
+ *     @SWG\Property(property="cid", type="integer"),
+ *     @SWG\Property(property="facility", type="string"),
+ *     @SWG\Property(property="active", type="integer", description="0 = inactive, 1 = active"),
+ *     @SWG\Property(property="created_at", type="string"),
+ * )
+ */
+class Visit extends Model
+{
+    protected $table = 'visits';
+
+    public function user()
+    {
+        return $this->belongsTo('App\User', 'cid', 'cid');
+    }
+}

--- a/database/migrations/2020_07_21_232439_create_visits_table.php
+++ b/database/migrations/2020_07_21_232439_create_visits_table.php
@@ -17,7 +17,6 @@ class CreateVisitsTable extends Migration
             $table->bigInteger('id', true)->unsigned();
             $table->integer('cid')->unsigned();
             $table->string('facility', 3);
-            $table->integer('active')->unsigned();
             $table->timestamps();
         });
     }

--- a/database/migrations/2020_07_21_232439_create_visits_table.php
+++ b/database/migrations/2020_07_21_232439_create_visits_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateVisitsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('visits', function (Blueprint $table) {
+            $table->bigInteger('id', true)->unsigned();
+            $table->integer('cid')->unsigned();
+            $table->string('facility', 3);
+            $table->integer('active')->unsigned();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('visits');
+    }
+}

--- a/routes/api-v2.php
+++ b/routes/api-v2.php
@@ -114,13 +114,6 @@ Route::group(['middleware' => 'auth:web,jwt'], function () {
     ]);
     Route::post('facility/{id}/email/{templateName}', 'FacilityController@postEmailTemplate');
 });
-Route::group(['middleware' => 'semiprivate'], function () {
-    Route::get('facility/{id}/transfers', 'FacilityController@getTransfers')->where('id', '[A-Za-z]{3}');
-    Route::get('facility/{id}/email/{templateName}', 'FacilityController@getemailTemplate');
-    Route::get('facility/{id}/ulsReturns', 'FacilityController@getUlsReturns');
-    Route::post('facility/{id}/ulsReturns', 'FacilityController@addUlsReturn');
-    Route::delete('facility/{id}/ulsReturns/{order}', 'FacilityController@removeUlsReturn');
-    Route::put('facility/{id}/ulsReturns/{order}', 'FacilityController@putUlsReturn');
 Route::group(['prefix' => 'facility'], function () {
     Route::get('/', 'FacilityController@getIndex');
     Route::get('{id}', 'FacilityController@getFacility')->where('id', '[A-Za-z]{3}');
@@ -254,6 +247,8 @@ Route::group(['prefix' => '/user'], function () {
 
         Route::get('/{cid}/transfer/checklist', 'UserController@getTransferChecklist')->where('cid', '[0-9]+');
         Route::get('/{cid}/transfer/history', 'UserController@getTransferHistory')->where('cid', '[0-9]+');
+        Route::get('/{user}/training/records', 'TrainingController@getUserRecords')->where('user', '[0-9]+');
+        Route::post('/{user}/training/record', 'TrainingController@postNewRecord')->where('user', '[0-9]+');
     });
 
     Route::post('/{cid}/rating', 'UserController@postRating')->where('cid', '[0-9]+')
@@ -266,6 +261,8 @@ Route::group(['prefix' => '/user'], function () {
 
         Route::get('/{cid}/log', 'UserController@getActionLog')->where('cid', '[0-9]+');
         Route::post('/{cid}/log', 'UserController@postActionLog')->where('cid', '[0-9]+');
+        Route::get('/{user}/training/otsEvals', 'TrainingController@getUserOTSEvals')->where('user', '[0-9]+');
+        Route::post('/{user}/training/otsEval', 'TrainingController@postOTSEval')->where('user', '[0-9]+');
     });
 });
 
@@ -284,5 +281,22 @@ Route::group(['prefix' => '/tmu'], function () {
         Route::group(['middleware' => 'semiprivate'], function () {
             Route::post('/', 'TMUController@addNotice');
         });
+    });
+});
+
+/******************************************************************************************
+ * /training
+ * Training functions
+ */
+Route::group(['prefix' => 'training'], function () {
+    Route::group(['middleware' => 'semiprivate'], function () {
+        Route::get('record/{record}', 'TrainingController@getTrainingRecord')->where('record', '[0-9]+');
+        Route::delete('record/{record}', 'TrainingController@deleteRecord')->where('record', '[0-9]+');
+        Route::put('record/{record}', 'TrainingController@editRecord')->where('record', '[0-9]+');
+    });
+    Route::group(['middleware' => 'private'], function() {
+        Route::get('records', 'TrainingController@getAllRecords');
+        Route::get('otsEval/{eval}', 'TrainingController@getOTSEval')->where('eval', '[0-9]+');
+        Route::get('record/{record}/otsEval', 'TrainingController@getOTSTrainingEval')->where('record', '[0-9]+');
     });
 });

--- a/routes/api-v2.php
+++ b/routes/api-v2.php
@@ -216,6 +216,8 @@ Route::group(['prefix' => '/survey', 'middleware' => 'private'], function () {
  */
 
 Route::group(['prefix' => '/user'], function () {
+    Route::get('/filtercid/{partialCid}', 'UserController@filterUsersCid')->where('partialCid', '[0-9]+');
+    Route::get('/filterlname/{partialLName}', 'UserController@filterUsersLName')->where('partialLName', '[A-Za-z0-9]+');
     Route::get('/{cid}', 'UserController@getIndex')->where('cid', '[0-9]+');
 
     Route::get('/roles/{facility}/{role}', 'UserController@getRoleUsers')->where([

--- a/routes/api-v2.php
+++ b/routes/api-v2.php
@@ -94,17 +94,17 @@ Route::group(['middleware' => ['private', 'auth:jwt,web'], 'prefix' => '/exam'],
 Route::get('facility', 'FacilityController@getIndex');
 Route::get('facility/{id}', 'FacilityController@getFacility')->where('id', '[A-Za-z]{3}');
 Route::get('facility/{id}/roster/{membership?}', 'FacilityController@getRoster')->where('id', '[A-Za-z]{3}');
-Route::post('facility/{id}/roster/manageVisitor/{cid}', 'FacilityController@addVisitor')->where([
-    'id'  => '[A-Za-z]{3}',
-    'cid' => '\d+'
-]);
-Route::delete('facility/{id}/roster/manageVisitor/{cid}', 'FacilityController@removeVisitor')->where([
-    'id'  => '[A-Za-z]{3}',
-    'cid' => '\d+'
-]);
 Route::group(['middleware' => 'auth:web,jwt'], function () {
     Route::put('facility/{id}', 'FacilityController@putFacility')->where('id', '[A-Za-z]{3}');
     Route::delete('facility/{id}/roster/{cid}', 'FacilityController@deleteRoster')->where([
+        'id'  => '[A-Za-z]{3}',
+        'cid' => '\d+'
+    ]);
+    Route::post('facility/{id}/roster/manageVisitor/{cid}', 'FacilityController@addVisitor')->where([
+        'id'  => '[A-Za-z]{3}',
+        'cid' => '\d+'
+    ]);
+    Route::delete('facility/{id}/roster/manageVisitor/{cid}', 'FacilityController@removeVisitor')->where([
         'id'  => '[A-Za-z]{3}',
         'cid' => '\d+'
     ]);

--- a/routes/api-v2.php
+++ b/routes/api-v2.php
@@ -93,8 +93,15 @@ Route::group(['middleware' => ['private', 'auth:jwt,web'], 'prefix' => '/exam'],
 
 Route::get('facility', 'FacilityController@getIndex');
 Route::get('facility/{id}', 'FacilityController@getFacility')->where('id', '[A-Za-z]{3}');
-Route::get('facility/{id}/staff', 'FacilityController@getStaff')->where('id', '[A-Za-z]{3}');
-Route::get('facility/{id}/roster', 'FacilityController@getRoster')->where('id', '[A-Za-z]{3}');
+Route::get('facility/{id}/roster/{membership?}', 'FacilityController@getRoster')->where('id', '[A-Za-z]{3}');
+Route::post('facility/{id}/roster/manageVisitor/{cid}', 'FacilityController@addVisitor')->where([
+    'id'  => '[A-Za-z]{3}',
+    'cid' => '\d+'
+]);
+Route::delete('facility/{id}/roster/manageVisitor/{cid}', 'FacilityController@removeVisitor')->where([
+    'id'  => '[A-Za-z]{3}',
+    'cid' => '\d+'
+]);
 Route::group(['middleware' => 'auth:web,jwt'], function () {
     Route::put('facility/{id}', 'FacilityController@putFacility')->where('id', '[A-Za-z]{3}');
     Route::delete('facility/{id}/roster/{cid}', 'FacilityController@deleteRoster')->where([


### PR DESCRIPTION
This pull request adds support for a centralized visiting roster along with other miscellaneous changes.

- Added `Visit` model.
- Added `/facility/{id}/roster/manageVisitor/{cid}` endpoint for adding and removing visitors.
- Added `{membership}` URL parameter to roster endpoint.
- Added `visiting_facilities` key to user endpoint.
- Added `lastPromotion()` to `User` model and the `last_promotion` key to user and facility roster endpoints.
- Added `/user/filtercid/{partialcid}` endpoint, returns list of controllers matching the given partial CID.
- Added `/user/filterlname/{partialcid}` endpoint, returns list of controllers matching the given partial last name.