### PR TITLE
Fixed transfer eligibility check for I1+

### DIFF
--- a/app/Http/Controllers/API/v2/FacilityController.php
+++ b/app/Http/Controllers/API/v2/FacilityController.php
@@ -645,12 +645,12 @@ class FacilityController extends APIController
             $rosterArr[$i]['rating_short'] = RatingHelper::intToShort($member->rating);
 
             //Is Mentor
-            $rosterArr[$i]['isMentor'] = $member->roles->where("facility", $id)
+            $rosterArr[$i]['isMentor'] = $member->roles->where("facility", $member->facility)
                     ->where("role", "MTR")->count() > 0;
 
             //Has Ins Perms
             $rosterArr[$i]['isSupIns'] = $roster[$i]['rating_short'] === "SUP" &&
-                $member->roles->where("facility", $id)
+                $member->roles->where("facility", $member->facility)
                     ->where("role", "INS")->count() > 0;
 
             //Last promotion date
@@ -662,11 +662,11 @@ class FacilityController extends APIController
             }
 
             //Membership
-            if ($member->facility == $id) {
+            if ($member->facility == $facility->id) {
                 $rosterArr[$i]['membership'] = 'home';
             } else {
                 $rosterArr[$i]['membership'] = 'visit';
-                $rosterArr[$i]['facility_join'] = Visit::where('facility', $id)
+                $rosterArr[$i]['facility_join'] = Visit::where('facility', $facility->id)
                     ->where('cid', $member->cid)->first()->updated_at;
             }
 
@@ -752,14 +752,14 @@ class FacilityController extends APIController
         }
 
         // Checks if user is a member at the specified facility
-        if ($user->facility == $id) {
+        if ($user->facility == $facility->id) {
             return response()->api(
                 generate_error("User is a member at this facility"), 400
             );
         }
 
         // Checks if the visit already exists
-        $visit = Visit::where('cid', $cid)->where('facility', $id)->first();
+        $visit = Visit::where('cid', $cid)->where('facility', $facility->id)->first();
         if ($visit) {
             return response()->api(
                 generate_error("User is already visiting this facility"), 400
@@ -767,7 +767,7 @@ class FacilityController extends APIController
         } else {
             $visitor = new Visit();
             $visitor->cid = $user->cid;
-            $visitor->facility = $id;
+            $visitor->facility = $facility->id;
             $visitor->save();
 
             log_action($user->cid, "User added to $facility->id visiting roster by " . \Auth::user()->fullname()
@@ -865,7 +865,7 @@ class FacilityController extends APIController
         }
 
         // Checks if user is a member at the specified facility
-        $visit = Visit::where('cid', $cid)->where('facility', $id)->first();
+        $visit = Visit::where('cid', $cid)->where('facility', $facility->id)->first();
         if (!$visit) {
             return response()->api(
                 generate_error("User is not visiting this facility"), 412

--- a/app/User.php
+++ b/app/User.php
@@ -564,9 +564,8 @@ class User extends Model implements AuthenticatableContract, JWTSubject
         // S1-C1 within 90 check
         $promotion = Promotion::where('cid', $this->cid)->where([
             ['to',         '<=', Helper::ratingIntFromShort("C1")],
-            ['to',         '>', 'from'],
             ['created_at', '>=', \DB::raw("DATE(NOW() - INTERVAL 90 DAY)")]
-        ])->first();
+        ])->whereRaw('promotions.to > promotions.from')->first();
 
         if ($promotion == null) {
             $checks['promo'] = 1;


### PR DESCRIPTION
- Users who have been demoted from an I1+ rating are now able to submit a transfer request without needing to pass the S1-C1 within 90 days check.
- Fix case sensitivity when accessing the facility/roster endpoint.