### PR TITLE
Visiting Facility in ULS token response [Extension]

### DIFF
--- a/app/Http/Controllers/Login/ULSv2Controller.php
+++ b/app/Http/Controllers/Login/ULSv2Controller.php
@@ -168,7 +168,8 @@ class ULSv2Controller extends Controller
                 'id'   => $facility->id,
                 'name' => $facility->name
             ],
-            'roles'     => []
+            'roles'     => [],
+            'visiting_facilities'  => $user->visits->toArray();,
         ];
         foreach (Role::where('cid', $user->cid)->where('facility', $facility->id)->get() as $role) {
             $data['roles'][] = $role->role;

--- a/app/Http/Controllers/Login/ULSv2Controller.php
+++ b/app/Http/Controllers/Login/ULSv2Controller.php
@@ -169,7 +169,7 @@ class ULSv2Controller extends Controller
                 'name' => $facility->name
             ],
             'roles'     => [],
-            'visiting_facilities'  => $user->visits->toArray();,
+            'visiting_facilities'  => $user->visits->toArray(),
         ];
         foreach (Role::where('cid', $user->cid)->where('facility', $facility->id)->get() as $role) {
             $data['roles'][] = $role->role;


### PR DESCRIPTION
This changes the ULS return object to add an array of visiting facilities to the user object. The intention is to reduce calls to the division API while simultaneously checking that the user is on the visiting list at login (thereby not having to also query GET /user/cid).