### PR TITLE
Add RFC7519 flag to authorize query to add compliance for Sub in JWT

### DIFF
--- a/app/Helpers/ULSHelper.php
+++ b/app/Helpers/ULSHelper.php
@@ -38,12 +38,12 @@ class ULSHelper
         return $token;
     }
 
-    public static function generatev2Token(User $user, Facility $facility)
+    public static function generatev2Token(User $user, Facility $facility, bool $rfc7519)
     {
         $data = [
             'iss' => 'VATUSA',
             'aud' => $facility->id,
-            'sub' => $user->cid,
+            'sub' => $rfc7519 ? string($user->cid) : $user->cid,
             'ip'  => isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : 'not available',
             'iat' => time(),
             'nbf' => time(),

--- a/app/Http/Controllers/Login/ULSv2Controller.php
+++ b/app/Http/Controllers/Login/ULSv2Controller.php
@@ -35,6 +35,7 @@ class ULSv2Controller extends Controller
     {
         $fac = $request->input('fac', null);
         $test = $request->has('test');
+        $rfc7519_compliance = $request->has("rfc7519_compliance");
 
         $url = $request->input('url', 1);
         if ($request->has('dev') && !$request->has('url')) {
@@ -61,7 +62,7 @@ class ULSv2Controller extends Controller
                 "Facility is not ready for ULSv2. Please contact the facility webmaster at " . strtolower($facility->id) . "-wm@vatusa.net");
         }
 
-        session(compact('fac', 'url', 'test'));
+        session(compact('fac', 'url', 'test', 'rfc7519_compliance'));
 
         return redirect(env(!$test ? 'ULSv2_LOGIN' : 'SSO_RETURN_ULSv2'));
         //Testing: return test user using dev JWK key
@@ -72,6 +73,7 @@ class ULSv2Controller extends Controller
         $fac = $request->session()->has('fac') ? $request->session()->get('fac') : null;
         $url = $request->session()->has('url') ? $request->session()->get('url') : null;
         $test = $request->session()->has('test') ? $request->session()->get('test') : null;
+        $rfc7519_compliance = $request->session()->has("rfc7519_compliance") ? $request->session()->has("rfc7519_compliance") : null;
 
         if (!$fac || !$url) {
             abort(400, "Malformed request");
@@ -98,7 +100,7 @@ class ULSv2Controller extends Controller
         );
 
         $data = ULSHelper::generatev2Token(!$test ? \Auth::user() : factory(User::class)->make(['facility' => "ZXX"]),
-            $facility);
+            $facility, $rfc7519_compliance ? true : false);
         $payload = $jsonConverter->encode($data);
         $jws = $jwsBuilder->create()->withPayload($payload)->addSignature($jwk,
             ['alg' => $facility_jwk['alg']])->build();


### PR DESCRIPTION
This adds a query param of `rfc7519_compliance` to the login endpoint of ULSv2, that when set (no value, just has to exist in the query string to be "set" like test), will have the Subject Claim be a string in compliance with RFC 7519 https://datatracker.ietf.org/doc/html/rfc7519#page-9.  This change uses a flag to ensure it is a non-breaking change for existing code bases, but is not enough of a change to warrant versioning to v3.

Closes #61 