### PR TITLE
Change max number of children

### DIFF
--- a/resources/docker/etc/php7/php-fpm.d/www.conf
+++ b/resources/docker/etc/php7/php-fpm.d/www.conf
@@ -50,7 +50,7 @@ pm = dynamic
 ; forget to tweak pm.* to fit your needs.
 ; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
-pm.max_children = 20
+pm.max_children = 40
 
 ; The number of child processes created on startup.
 ; Note: Used only when pm is set to 'dynamic'
@@ -65,7 +65,7 @@ pm.min_spare_servers = 1
 ; The desired maximum number of idle server processes.
 ; Note: Used only when pm is set to 'dynamic'
 ; Note: Mandatory when pm is set to 'dynamic'
-pm.max_spare_servers = 3
+pm.max_spare_servers = 5
 
 ;---------------------
 


### PR DESCRIPTION
There is a large number of requests that come in at the top of the hour that exhaust php-fpm's children pool. Because of this, a number of connections are failing to get a return resulting in 504 errors from the ingress.

This change doubles the number of children available, calculated by the current RAM usage of individual children and a reasonable amount of RAM usage from the current worker nodes in the k8 cluster.