### PR TITLE
Duplicate uls routes into versioned path

### DIFF
--- a/routes/login.php
+++ b/routes/login.php
@@ -14,8 +14,10 @@ Route::middleware(['login'])->group(function() {
 
 Route::prefix("/uls")->middleware(['login'])->group(function () {
     Route::prefix("/v2")->group(function() {
-       Route::get('login', 'ULSv2Controller@getLogin');
-       Route::get('redirect', 'ULSv2Controller@getRedirect');
-       Route::get('info', 'ULSv2Controller@getInfo');
+        Route::get('/', 'SSOController@getIndex');
+        Route::get('/return', 'SSOController@getReturn');
+        Route::get('/login', 'ULSv2Controller@getLogin');
+        Route::get('/redirect', 'ULSv2Controller@getRedirect');
+        Route::get('/info', 'ULSv2Controller@getInfo');
     });
 });


### PR DESCRIPTION
Currently VATUSA systems use login.vatusa.net/?home style pathing for ULSv2. As we prepare ULSv3 and endpoint-based routing, this needs to be moved.

This PR duplicates the routing, which will allow us to move things over time.