### PR TITLE
Allow senior staff to access training records via the API, even if not associated with their facility.

### DIFF
--- a/app/Http/Controllers/API/v2/TrainingController.php
+++ b/app/Http/Controllers/API/v2/TrainingController.php
@@ -1144,7 +1144,7 @@ class TrainingController extends Controller
                     Auth::user()->facility)->exists());
         $isTrainingStaff = Auth::user() && RoleHelper::isTrainingStaff(Auth::user()->cid, true,
                 $facility ?? Auth::user()->facility) && (!$record || ($record && ($record->student->facility == Auth::user()->facility || $record->facility->id == Auth::user()->facility)));
-        $isVATUSAStaff = Auth::user() && RoleHelper::isVATUSAStaff();
+        $isVATUSAStaff = Auth::user() && RoleHelper::isSeniorStaff(null, null, true);
         $ownsRecord = $record && Auth::user() && $record->student_id === Auth::user()->cid;
         $isOwnUser = Auth::user() && $user && $user->cid === Auth::user()->cid;
 


### PR DESCRIPTION
This change is required because the VATUSA website reads the contents of training records from the API.