### PR TITLE
Return proper Academy identifiers

### DIFF
--- a/app/Http/Controllers/API/v2/AcademyController.php
+++ b/app/Http/Controllers/API/v2/AcademyController.php
@@ -54,10 +54,10 @@ class AcademyController extends APIController
     public function getIdentifiers(Request $request)
     {
         return response()->api([
-            'BASIC' => config('exams.BASIC.id'),
-            'S2'    => config('exams.S2.id'),
-            'S3'    => config('exams.S3.id'),
-            'C1'    => config('exams.C1.id')
+            'BASIC' => config('exams.BASIC.courseId'),
+            'S2'    => config('exams.S2.courseId'),
+            'S3'    => config('exams.S3.courseId'),
+            'C1'    => config('exams.C1.courseId')
         ]);
     }
 


### PR DESCRIPTION
Changes academy identifiers endpoint to return course IDs instead of quiz IDs. Quiz IDs are not used externally.
Addresses initial issue identified in #85.