### PR TITLE
Show visiting_facilities in controller endpoint without auth.

### DIFF
--- a/app/Http/Controllers/API/v2/UserController.php
+++ b/app/Http/Controllers/API/v2/UserController.php
@@ -91,7 +91,6 @@ class UserController extends APIController
             $data['flag_broadcastOptedIn'] = null;
             $data['email'] = null;
             $data['visits'] = null;
-            $data['visiting_facilities'] = null;
             $data['academy_competencies'] = null;
             $data['promotions'] = null;
         }


### PR DESCRIPTION
This looks to be required by the VATUSA Discord bot in some servers for determining visitor roles.