### PR TITLE
Actually define `$cert` before using

### DIFF
--- a/app/Http/Controllers/API/v2/SoloController.php
+++ b/app/Http/Controllers/API/v2/SoloController.php
@@ -223,6 +223,7 @@ class SoloController extends APIController
         if (!isTest()) {
             if ($request->input("id", null)) {
                 try {
+                    $cert = SoloCert::findOrFail($request->input("id"));
                     $user = User::find($cert->cid);
                     if (\Auth::check() && !(RoleHelper::isSeniorStaff(Auth::user(),$user->facility,true) ||
                             RoleHelper::isVATUSAStaff(Auth::user()) ||


### PR DESCRIPTION
Fixes an error when attempting to delete a solo cert from the website: despite the record being very real, the API returns a 404 instead.