### PR TITLE
Add tini as init to reap api-worker zombie processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,7 @@ RUN	addgroup -S application && adduser -SG application application && \
 	apk add --update \
 	nginx \
 	supervisor \
+	tini \
 	openssh-client && \
 	cp /usr/local/etc/php/php.ini-production /usr/local/etc/php/php.ini && \
 	sed -i "s|;*daemonize\s*=\s*yes|daemonize = no|g" /usr/local/etc/php-fpm.conf && \
@@ -55,6 +56,13 @@ RUN php artisan l5-swagger:generate
 USER root
 RUN rm /usr/local/bin/composer.phar
 
-ENTRYPOINT ["/bin/sh","/www/build.sh"]
+# tini (PID 1) reaps orphaned child processes. The main pod runs supervisord
+# which reaps its own children, but the api-worker Deployment overrides this
+# ENTRYPOINT with `command: [php] artisan schedule:work`, leaving php as PID 1
+# with no reaper — its per-minute forked schedule tasks pile up as zombies.
+# tini here protects the main pod; the worker must also invoke tini via its
+# command (see gitops current/base/api/worker.yaml). -g forwards signals to the
+# whole process group so shutdown stays clean.
+ENTRYPOINT ["/sbin/tini","-g","--","/bin/sh","/www/build.sh"]
 
 EXPOSE 80


### PR DESCRIPTION
## Problem

The `api-worker` Deployment runs `php artisan schedule:work` as **PID 1** — its gitops `command: [php]` overrides this image's ENTRYPOINT, so `php` runs directly with no init. The Laravel scheduler forks each task (`vatsim:flights`, `moodle:*`) as a backgrounded subprocess every minute; when they exit they reparent to PID 1, but a plain `php` PID 1 never `wait()`s on them. They accumulate as `<defunct>` zombies and memory climbs unbounded.

Found live: a `current-dev` api-worker pod (up 59 days, `restartCount: 0`) holding **~52,000 zombies / 671Mi** — the single largest memory consumer in the cluster. Prod's api-worker had the identical defect (~2,847 zombies in 5 days). Nothing alerted because it never restarts and the 2000Mi limit is generous.

## Fix

Install `tini` and make it the image ENTRYPOINT (`/sbin/tini -g -- /bin/sh /www/build.sh`). Verified `tini` v0.19.0 installs to `/sbin/tini` on `php:8.1-fpm-alpine`. The main pod runs supervisord (which reaps its own children), so this is defense-in-depth there — but it puts the reaper binary in the image for the worker.

## ⚠️ Required companion change (sequenced)

This image change alone does **not** fix the worker, because its Kubernetes `command:` replaces the ENTRYPOINT. After this image is built and deployed, `gitops` `current/base/api/worker.yaml` must change its command to invoke tini:

```yaml
command: ["/sbin/tini", "-g", "--", "php"]
args: ["artisan", "schedule:work"]
```

**Order matters:** that gitops change must land only *after* this new image is live. If it merges first, the running pods (old image, no `/sbin/tini`) will crashloop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)