### PR TITLE
Fix moodle:sync stacking by cutting per-user Moodle HTTP call volume

### DIFF
--- a/app/Classes/VATUSAMoodle.php
+++ b/app/Classes/VATUSAMoodle.php
@@ -327,6 +327,21 @@ class VATUSAMoodle extends MoodleRest
     }
 
     /**
+     * Build a full CID -> Moodle user id map in a single query, to replace a
+     * whole-table per-user HTTP existence check with an in-memory lookup.
+     *
+     * @return \Illuminate\Support\Collection
+     */
+    public function getAllUserIdMap(): \Illuminate\Support\Collection
+    {
+        return DB::connection('moodle')->table('user')
+            ->where('deleted', 0)
+            ->whereNotNull('idnumber')
+            ->where('idnumber', '!=', '')
+            ->pluck('id', 'idnumber');
+    }
+
+    /**
      * Create user.
      *
      * @param \App\User $user
@@ -442,6 +457,30 @@ class VATUSAMoodle extends MoodleRest
     }
 
     /**
+     * Assign many users to Cohorts in a single request.
+     *
+     * @param array $items Each: ['uid' => int, 'cnumber' => string]
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public function assignCohortsBulk(array $items)
+    {
+        return $this->request("core_cohort_add_cohort_members", [
+            "members" => array_values(array_map(fn ($item) => [
+                "cohorttype" => [
+                    'type'  => 'idnumber',
+                    'value' => $item['cnumber']
+                ],
+                "usertype"   => [
+                    'type'  => 'id',
+                    'value' => $item['uid']
+                ]
+            ], $items))
+        ]);
+    }
+
+    /**
      * Unassign Cohort
      *
      * @param int $uid
@@ -488,6 +527,26 @@ class VATUSAMoodle extends MoodleRest
                     "contextlevel" => $context
                 ]
             ]
+        ]);
+    }
+
+    /**
+     * Assign many Roles in a single request.
+     *
+     * @param array $items Each: ['uid' => int, 'cid' => int|null, 'role' => string, 'context' => string]
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public function assignRolesBulk(array $items)
+    {
+        return $this->request("core_role_assign_roles", [
+            "assignments" => array_values(array_map(fn ($item) => [
+                "roleid"       => $this->roleIds[$item['role']],
+                "userid"       => $item['uid'],
+                "contextid"    => $item['cid'],
+                "contextlevel" => $item['context']
+            ], $items))
         ]);
     }
 
@@ -675,6 +734,27 @@ class VATUSAMoodle extends MoodleRest
 
         return $this->request("enrol_manual_enrol_users",
             ["enrolments" => [0 => ["roleid" => $rid, "userid" => $uid, "courseid" => $cid]]]);
+    }
+
+    /**
+     * Enrol many users in courses in a single request.
+     *
+     * @param array $items Each: ['uid' => int, 'cid' => int, 'rid' => int|null]
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public
+    function enrolUsersBulk(
+        array $items
+    ) {
+        return $this->request("enrol_manual_enrol_users", [
+            "enrolments" => array_values(array_map(fn ($item) => [
+                "roleid"   => $item['rid'] ?? $this->roleIds['STU'],
+                "userid"   => $item['uid'],
+                "courseid" => $item['cid']
+            ], $items))
+        ]);
     }
 
     /**

--- a/app/Console/Commands/MoodleSync.php
+++ b/app/Console/Commands/MoodleSync.php
@@ -62,10 +62,11 @@ class MoodleSync extends Command
         }
 
         //Syncronize Users
-        User::with('visits', 'academyCompetencies.course', 'roles')->chunk(1000, function ($users) {
+        $moodleIds = $this->moodle->getAllUserIdMap();
+        User::with('visits', 'academyCompetencies.course', 'roles')->chunk(1000, function ($users) use ($moodleIds) {
             foreach ($users as $user) {
-                if ($this->moodle->getUserId($user->cid)) {
-                    $this->sync($user);
+                if ($moodleIds->has($user->cid)) {
+                    $this->sync($user, (int) $moodleIds[$user->cid]);
                 }
             }
         });
@@ -77,13 +78,19 @@ class MoodleSync extends Command
      * Synchronize Roles
      *
      * @param \App\User $user
+     * @param int|null  $knownId Moodle user id, if already known (bulk sync path) — skips the
+     *                           redundant existence-check lookup that the single-user CLI path
+     *                           still needs to decide create-vs-update.
      *
      * @throws \Exception
      */
-    private function sync(User $user)
+    private function sync(User $user, ?int $knownId = null)
     {
         //Update or Create
-        if ($id = $this->moodle->getUserId($user->cid)) {
+        if ($knownId !== null) {
+            $id = $knownId;
+            $this->moodle->updateUser($user, $id);
+        } elseif ($id = $this->moodle->getUserId($user->cid)) {
             //Update Information
             $this->moodle->updateUser($user, $id);
         } else {
@@ -94,74 +101,113 @@ class MoodleSync extends Command
 
         //Assign Cohorts
         $this->moodle->clearUserCohorts($id);
-        $this->moodle->assignCohort($id,
-            Helper::ratingShortFromInt($user->rating)); //VATUSA level rating
+        $cohorts = [];
+        $cohorts[] = Helper::ratingShortFromInt($user->rating); //VATUSA level rating
         if ($user->flag_homecontroller) {
-            $this->moodle->assignCohort($id,
-                "$user->facility-" . Helper::ratingShortFromInt($user->rating)); //Facility level rating
+            $cohorts[] = "$user->facility-" . Helper::ratingShortFromInt($user->rating); //Facility level rating
             if (RoleHelper::userIsVATUSAStaff($user, false, true)
                 || RoleHelper::userIsInstructor($user)
                 || RoleHelper::userIsSeniorStaff($user, null, true)
                 || RoleHelper::userIsMentor($user)) {
-                $this->moodle->assignCohort($id, "TNG"); //Training staff
+                $cohorts[] = "TNG"; //Training staff
             }
         }
-        $this->moodle->assignCohort($id, $user->facility); //Home Facility
+        $cohorts[] = $user->facility; //Home Facility
 
         foreach ($user->visits->pluck('facility') as $facility) {
             //Visiting Facilities
-            $this->moodle->assignCohort($id, $facility . "-V"); //Facility level visitor
-            $this->moodle->assignCohort($id,
-                "$facility-" . Helper::ratingShortFromInt($user->rating)); //Facility level rating
+            $cohorts[] = $facility . "-V"; //Facility level visitor
+            $cohorts[] = "$facility-" . Helper::ratingShortFromInt($user->rating); //Facility level rating
         }
+        if (!empty($cohorts)) {
+            $this->moodle->assignCohortsBulk(array_map(fn ($cnumber) => ['uid' => $id, 'cnumber' => $cnumber],
+                $cohorts));
+        }
+
         //Clear Roles
         $this->moodle->clearUserRoles($id);
 
+        $roles = [];
         //Assign Student Role
         foreach ($facilities as $facility) {
-            $this->moodle->assignRole($id, $this->moodle->getCategoryFromShort($facility, true), "STU", "coursecat");
+            $roles[] = [
+                'uid'     => $id,
+                'cid'     => $this->moodle->getCategoryFromShort($facility, true),
+                'role'    => "STU",
+                'context' => "coursecat"
+            ];
         }
 
         //Assign Category Permissions
+        $enrolments = [];
         if (RoleHelper::userIsVATUSAStaff($user, false, true) || RoleHelper::userIsSeniorStaff($user, $user->facility,
                 true)) {
-            $this->moodle->assignRole($id, VATUSAMoodle::CATEGORY_CONTEXT_VATUSA, "INS", "coursecat");
-            $this->moodle->assignRole($id, $this->moodle->getCategoryFromShort($user->facility, true), "TA",
-                "coursecat");
+            $roles[] = [
+                'uid' => $id, 'cid' => VATUSAMoodle::CATEGORY_CONTEXT_VATUSA, 'role' => "INS",
+                'context' => "coursecat"
+            ];
+            $roles[] = [
+                'uid'     => $id,
+                'cid'     => $this->moodle->getCategoryFromShort($user->facility, true),
+                'role'    => "TA",
+                'context' => "coursecat"
+            ];
             $artccCategories = $this->moodle->getAllSubcategories($this->moodle->getCategoryFromShort($user->facility),
                 true);
             foreach ($artccCategories as $category) {
                 $courses = $this->moodle->getCoursesInCategory($category);
                 foreach ($courses as $course) {
-                    $this->moodle->enrolUser($id, $course["id"]);
+                    $enrolments[] = ['uid' => $id, 'cid' => $course["id"]];
                 }
             }
         }
         if (RoleHelper::userIsVATUSAStaff($user, false, true) || RoleHelper::userHas($user, "ZAE", "CBT")) {
-            $this->moodle->assignRole($id, VATUSAMoodle::CATEGORY_CONTEXT_VATUSA, "CBT", "coursecat");
+            $roles[] = [
+                'uid' => $id, 'cid' => VATUSAMoodle::CATEGORY_CONTEXT_VATUSA, 'role' => "CBT",
+                'context' => "coursecat"
+            ];
         }
         if (RoleHelper::userIsVATUSAStaff($user, false, true) || RoleHelper::userHas($user, $user->facility,
                 "FACCBT")) {
-            $this->moodle->assignRole($id, $this->moodle->getCategoryFromShort($user->facility, true), "FACCBT",
-                "coursecat");
+            $roles[] = [
+                'uid'     => $id,
+                'cid'     => $this->moodle->getCategoryFromShort($user->facility, true),
+                'role'    => "FACCBT",
+                'context' => "coursecat"
+            ];
         }
         if (RoleHelper::userIsVATUSAStaff($user, false, true) || RoleHelper::userIsInstructor($user,
                 $user->facility)) {
-            $this->moodle->assignRole($id, VATUSAMoodle::CATEGORY_CONTEXT_VATUSA, "INS", "coursecat");
-            $this->moodle->assignRole($id, $this->moodle->getCategoryFromShort($user->facility, true), "INS",
-                "coursecat");
+            $roles[] = [
+                'uid' => $id, 'cid' => VATUSAMoodle::CATEGORY_CONTEXT_VATUSA, 'role' => "INS",
+                'context' => "coursecat"
+            ];
+            $roles[] = [
+                'uid'     => $id,
+                'cid'     => $this->moodle->getCategoryFromShort($user->facility, true),
+                'role'    => "INS",
+                'context' => "coursecat"
+            ];
         }
         if (RoleHelper::userIsVATUSAStaff($user, false, true) || RoleHelper::userIsMentor($user)) {
             for ($i = Helper::ratingIntFromShort("S1"); $i <= $user->rating; $i++) {
                 $context = "EXAM_CONTEXT_" . Helper::ratingShortFromInt($i);
-                $this->moodle->assignRole($id, $this->moodle->getConstant($context), "MTR", "course");
+                $roles[] = [
+                    'uid' => $id, 'cid' => $this->moodle->getConstant($context), 'role' => "MTR",
+                    'context' => "course"
+                ];
             }
         }
 
         /*if (Role::where("cid", $user->cid)->where("facility", $user->facility)->where("role", "MTR")->exists()) {
-            $this->moodle->assignRole($id, $this->moodle->getCategoryFromShort($user->facility, true), "MTR",
-                "coursecat");
+            $roles[] = ['uid' => $id, 'cid' => $this->moodle->getCategoryFromShort($user->facility, true), 'role' => "MTR", 'context' => "coursecat"];
         }*/
 
+        if (!empty($roles)) {
+            $this->moodle->assignRolesBulk($roles);
+        }
+        if (!empty($enrolments)) {
+            $this->moodle->enrolUsersBulk($enrolments);
+        }
     }
 }

--- a/tests/Unit/MoodleUserIdMapTest.php
+++ b/tests/Unit/MoodleUserIdMapTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit;
+
+use Illuminate\Support\Collection;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Pure unit test — does not boot the Laravel application or touch a database.
+ *
+ * VATUSAMoodle::getAllUserIdMap() builds its map via
+ * DB::table('user')->pluck('id', 'idnumber'), where the Moodle DB's `idnumber`
+ * column is a VARCHAR holding the VATUSA CID as a string. MoodleSync::handle()
+ * then looks entries up with the integer $user->cid. This test locks in the
+ * assumption that swap relies on: PHP normalizes numeric string array keys to
+ * integers, so Collection::has()/offsetGet() with an int CID still matches a
+ * map keyed from string column values.
+ */
+class MoodleUserIdMapTest extends TestCase
+{
+    public function test_int_cid_lookup_matches_string_keyed_map(): void
+    {
+        // Simulates DB::connection('moodle')->table('user')->pluck('id', 'idnumber'),
+        // where idnumber is fetched as a string from a VARCHAR column.
+        $moodleIds = new Collection([
+            '1234567' => 42,
+            '7654321' => 99,
+        ]);
+
+        $this->assertTrue($moodleIds->has(1234567));
+        $this->assertSame(42, $moodleIds[1234567]);
+
+        $this->assertFalse($moodleIds->has(9999999));
+    }
+
+    public function test_users_absent_from_moodle_are_skipped(): void
+    {
+        $moodleIds = new Collection(['1234567' => 42]);
+
+        $cidsToSync = collect([1234567, 2222222, 7654321])
+            ->filter(fn ($cid) => $moodleIds->has($cid))
+            ->values();
+
+        $this->assertSame([1234567], $cidsToSync->all());
+    }
+}


### PR DESCRIPTION
## Summary

`moodle:sync` runs on a 3-hour schedule in the `current` namespace `api-worker` pod. A single run was taking **17+ hours**, so new runs kept stacking on top of unfinished ones — 6 concurrent instances observed live on the pod, each ~55-63MB RSS, driving CPU to the pod's limit and climbing day over day. Left alone this was on track to eventually OOM the pod.

## Why #111 didn't fix it

#111 (merged/deployed 2026-07-19) memoized `VATUSAMoodle::getCategories()` and added a 30s per-call HTTP timeout, on the theory that a category-fetch N+1 was what pushed a run past the 120-minute `withoutOverlapping()` lock. Two days after that deploy, the pod still had 6 stacked `moodle:sync` processes with elapsed times 17h47m → 2h47m — one per missed 3-hour tick, none ever completing. So the N+1 fix was real but not the dominant cost.

**Actual root cause:** `MoodleSync::handle()` walks the *entire* VATUSA user table and fires one `core_user_get_users` HTTP call per user just to check "is this CID in Moodle?" The large majority of users aren't, so this alone is tens of thousands of sequential round-trips per run. Every user who *is* in Moodle then triggers several more one-item-at-a-time write calls (cohorts, roles, enrolments) — staff users trigger dozens via a nested category/course enrolment loop. Runtime > the 120-minute lock window, so the lock auto-expires mid-run and the next scheduler tick starts a fresh overlapping instance.

Per `api/CLAUDE.md`, that 120-minute window on `moodle:sync` was deliberately shortened (commit `a324474`) so an *orphaned* lock (left behind by a pod restart/OOM) self-heals in ~1-2h instead of Laravel's 24h default — so widening it isn't an option. This PR instead cuts real runtime back under the existing window.

## What's changing — using Moodle's bulk endpoints

Moodle's Web Service functions are bulk-capable almost everywhere (they accept arrays), but our wrappers only ever called them with single-element arrays, paying one HTTP round-trip per item. This PR:

1. **Kills the whole-table existence-check HTTP storm.** Adds `VATUSAMoodle::getAllUserIdMap()`, which builds a full `CID -> Moodle user id` map with **one query** against the Moodle DB connection this class already uses elsewhere (`clearUserCohorts`, `getContext`, etc. all use `DB::connection('moodle')`). `MoodleSync::handle()` now does an in-memory lookup against that map instead of an HTTP call per VATUSA user, and passes the known id into `sync()` so its own redundant second `getUserId()` call is skipped too. This removes ~all of the dominant cost.
2. **Batches the per-user write calls.** Adds `assignCohortsBulk()`, `assignRolesBulk()`, `enrolUsersBulk()` to `VATUSAMoodle` (the existing single-item methods are untouched — other callers depend on them: `ULSHelper`, `AcademyController`, `MoodleCompetency`). `sync()` now collects each user's cohort/role/enrolment items and flushes each as one bulk call, turning ~5-30 calls/user into ~3-4.

**Explicitly unchanged:** `Kernel.php` scheduling, the `withoutOverlapping()` values, and every existing `VATUSAMoodle` method signature. The single-user `moodle:sync {cid}` CLI path still does its original create-or-update `getUserId()` lookup — only the whole-table bulk path changed.

## Behavior preservation

The bulk sync path only ever iterated users that passed `if ($this->moodle->getUserId($user->cid))` — i.e. users already confirmed to exist in Moodle; it never created new users from that path. Iterating `$moodleIds->has($user->cid)` against the new map is equivalent, so no user that was previously synced is now skipped, and no user is newly synced that wasn't before. Per-user batching doesn't change ordering relative to other users, and each user's own clear-then-assign sequence (`clearUserCohorts`/`clearUserRoles` happen before the corresponding bulk assign, same as before) is preserved.

## Testing

* Local: `./vendor/bin/phpunit` — 5/5 passing, including a new `tests/Unit/MoodleUserIdMapTest.php` covering the one non-obvious assumption the swap relies on (an int CID lookup matching a map keyed from the Moodle DB's string `idnumber` column values, via PHP's numeric-string array key coercion).
* The existing suite is smoke-only (in-memory SQLite, no real Moodle), so the bulk Moodle calls themselves can't be integration-tested locally.

### Recommended before merging to prod traffic

* [x] Deploy this branch to a dev/staging overlay first.
* [ ] Run `php artisan moodle:sync` manually and time it — expect **minutes**, not hours.
* [ ] Spot-check a few users' cohorts/roles/enrolments in Moodle match what the old per-item path produced (no behavioral drift from batching).
* [ ] After deploying to prod, confirm via `kubectl -n current exec <api-worker-pod> -- ps -o pid,etime,rss,args` that at most one `moodle:sync` process is ever live, and that it completes well within the 3-hour interval. Cross-check logs for matching `Starting`/`Finished scheduled task: moodle:sync` pairs (the `after` hook never fired while the job was stuck) and watch pod CPU/memory flatten instead of climbing.

## Risks

* **Bulk-call atomicity is unverified.** Moodle's bulk Web Service functions accept an array of items in one call; if one item in the array is invalid (e.g. a category lookup returned `null` for a context id), it's not confirmed whether Moodle rejects the whole batch or processes valid items and reports per-item errors. Worth watching for on the staging run and after prod rollout — if it does hard-fail whole batches, a bad category mapping for one facility could now block cohort/role assignment for other facilities in the same call, where before it would only have failed that one item.
* **`getAllUserIdMap()` reads `idnumber`/`deleted` directly from the Moodle DB**, same access pattern as existing methods in this class, but it's a new query shape — if Moodle's schema differs from what's assumed (`idnumber` as the CID, `deleted = 0` for active users), the map could be built incorrectly. Worth a spot-check against real data in staging.
* Scope is intentionally narrow: no changes to `MoodleCompetency.php`, the scheduler config, or the timeout PR #111 already added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)