### PR TITLE
Diff moodle:sync role assignments instead of clearing and reassigning every run

### DIFF
--- a/app/Classes/VATUSAMoodle.php
+++ b/app/Classes/VATUSAMoodle.php
@@ -643,6 +643,40 @@ class VATUSAMoodle extends MoodleRest
     }
 
     /**
+     * Map a role short name (STU/INS/TA/...) to its Moodle role id, so the sync can diff
+     * desired roles (expressed as short names) against current assignments (stored as role
+     * ids) without exposing the internal $roleIds map.
+     *
+     * @param string $role
+     *
+     * @return int|null
+     */
+    public function roleIdFor(string $role): ?int
+    {
+        return $this->roleIds[$role] ?? null;
+    }
+
+    /**
+     * Unassign many role assignments in a single request.
+     *
+     * @param array $items Each: ['uid' => int, 'roleid' => int, 'contextid' => int, 'contextlevel' => int]
+     *
+     * @return mixed
+     * @throws \Exception
+     */
+    public function unassignRolesBulk(array $items)
+    {
+        return $this->request("core_role_unassign_roles", [
+            "unassignments" => array_values(array_map(fn ($item) => [
+                "roleid"       => $item['roleid'],
+                "userid"       => $item['uid'],
+                "contextid"    => $item['contextid'],
+                "contextlevel" => $item['contextlevel']
+            ], $items))
+        ], self::METHOD_POST);
+    }
+
+    /**
      *
      * Remove Role from User in Context
      *
@@ -732,6 +766,55 @@ class VATUSAMoodle extends MoodleRest
                 DB::connection('moodle')->table('role_assignments')->where('id', $id)->delete();
             }
         }
+    }
+
+    /**
+     * Read the "sync-managed" role assignments for a set of users in a single query, so a
+     * bulk sync can diff desired vs. current and only write actual changes. The filter here
+     * MUST mirror clearUserRoles()'s default branch exactly — it defines the set of
+     * assignments the sync owns (coursecat roles, plus non-STU roles on exam courses under
+     * the VATUSA/exams context path, excluding enrolment-derived components). Anything
+     * outside this set is left untouched, exactly as clear-then-reassign did.
+     *
+     * @param int[] $uids Moodle user ids
+     *
+     * @return array<int,array<int,array{roleid:int,contextid:int,contextlevel:int}>>
+     *         userid => list of managed role assignments
+     */
+    public function getManagedRoleAssignmentsForUsers(array $uids): array
+    {
+        if (empty($uids)) {
+            return [];
+        }
+
+        $prefix = config('database.connections.moodle.prefix');
+        $map = [];
+        DB::connection('moodle')->table('role_assignments')
+            ->selectRaw($prefix . 'role_assignments.roleid, ' . $prefix . 'role_assignments.userid, '
+                . $prefix . 'role_assignments.contextid, context.contextlevel')
+            ->leftJoin('context', 'role_assignments.contextid', '=', 'context.id')
+            ->whereIn('role_assignments.userid', $uids)
+            ->where(function ($query) {
+                $query->where('context.contextlevel', self::CONTEXT_COURSECAT);
+                $query->orWhere(function ($query) {
+                    $query->where('context.contextlevel', self::CONTEXT_COURSE);
+                    $query->where('context.path', 'LIKE',
+                        '%' . self::CATEGORY_CONTEXT_VATUSA . '/' . self::CATEGORY_CONTEXT_VATUSA_EXAMS . '/%');
+                    $query->where('role_assignments.roleid', '!=', $this->roleIds['STU']);
+                });
+            })
+            ->where('role_assignments.component', '!=', 'enrol_cohort')
+            ->where('role_assignments.component', '!=', 'enrol_coursecompleted')
+            ->get()
+            ->each(function ($row) use (&$map) {
+                $map[(int) $row->userid][] = [
+                    'roleid'       => (int) $row->roleid,
+                    'contextid'    => (int) $row->contextid,
+                    'contextlevel' => (int) $row->contextlevel
+                ];
+            });
+
+        return $map;
     }
 
     /**

--- a/app/Console/Commands/MoodleSync.php
+++ b/app/Console/Commands/MoodleSync.php
@@ -81,16 +81,17 @@ class MoodleSync extends Command
         logger()->info("moodle:sync starting bulk pass: {$moodleIds->count()} Moodle-linked users");
 
         $chunkNum = 0;
-        $totals = ['users' => 0, 'cohortAdds' => 0, 'cohortRemoves' => 0, 'roles' => 0,
-                   'enrolments' => 0, 'failedBatches' => 0];
+        $totals = ['users' => 0, 'cohortAdds' => 0, 'cohortRemoves' => 0,
+                   'roleAdds' => 0, 'roleRemoves' => 0, 'enrolments' => 0, 'failedBatches' => 0];
 
         User::with('visits', 'academyCompetencies.course', 'roles')->chunk(1000,
             function ($users) use ($moodleIds, $cohortIdMap, &$chunkNum, &$totals) {
                 $chunkNum++;
 
                 // Resolve this chunk's users to their Moodle ids up front, then read all
-                // their current cohort memberships in one query so we can diff desired vs.
-                // current and only write actual changes (see diffCohorts()).
+                // their current cohort memberships and managed role assignments in one query
+                // each, so we can diff desired vs. current and only write actual changes
+                // (see diffCohorts()/diffRoles()).
                 $chunkUsers = [];
                 foreach ($users as $user) {
                     if ($moodleIds->has($user->cid)) {
@@ -98,18 +99,22 @@ class MoodleSync extends Command
                     }
                 }
                 $currentCohorts = $this->moodle->getCohortMembershipsForUsers(array_keys($chunkUsers));
+                $currentRoles = $this->moodle->getManagedRoleAssignmentsForUsers(array_keys($chunkUsers));
 
-                $updates = $cohortAdds = $cohortRemoves = $roles = $enrolments = [];
+                $updates = $cohortAdds = $cohortRemoves = $roleAdds = $roleRemoves = $enrolments = [];
                 foreach ($chunkUsers as $id => $user) {
                     $items = $this->computeSyncItems($user, $id);
                     $updates[] = $items['update'];
 
-                    $diff = $this->diffCohorts($id, $items['cohortIdnumbers'],
+                    $cohortDiff = $this->diffCohorts($id, $items['cohortIdnumbers'],
                         $currentCohorts[$id] ?? [], $cohortIdMap);
-                    $cohortAdds = array_merge($cohortAdds, $diff['adds']);
-                    $cohortRemoves = array_merge($cohortRemoves, $diff['removes']);
+                    $cohortAdds = array_merge($cohortAdds, $cohortDiff['adds']);
+                    $cohortRemoves = array_merge($cohortRemoves, $cohortDiff['removes']);
 
-                    $roles = array_merge($roles, $items['roles']);
+                    $roleDiff = $this->diffRoles($id, $items['roles'], $currentRoles[$id] ?? []);
+                    $roleAdds = array_merge($roleAdds, $roleDiff['adds']);
+                    $roleRemoves = array_merge($roleRemoves, $roleDiff['removes']);
+
                     $enrolments = array_merge($enrolments, $items['enrolments']);
                 }
 
@@ -123,7 +128,10 @@ class MoodleSync extends Command
                 $failed += $this->flushBulk($chunkNum, 'cohort-adds', $cohortAdds,
                     fn ($items) => $this->moodle->assignCohortsBulk($items));
                 usleep(self::FLUSH_PACING_USEC);
-                $failed += $this->flushBulk($chunkNum, 'roles', $roles,
+                $failed += $this->flushBulk($chunkNum, 'role-removes', $roleRemoves,
+                    fn ($items) => $this->moodle->unassignRolesBulk($items));
+                usleep(self::FLUSH_PACING_USEC);
+                $failed += $this->flushBulk($chunkNum, 'role-adds', $roleAdds,
                     fn ($items) => $this->moodle->assignRolesBulk($items));
                 usleep(self::FLUSH_PACING_USEC);
                 $failed += $this->flushBulk($chunkNum, 'enrolments', $enrolments,
@@ -132,19 +140,22 @@ class MoodleSync extends Command
                 $totals['users'] += count($chunkUsers);
                 $totals['cohortAdds'] += count($cohortAdds);
                 $totals['cohortRemoves'] += count($cohortRemoves);
-                $totals['roles'] += count($roles);
+                $totals['roleAdds'] += count($roleAdds);
+                $totals['roleRemoves'] += count($roleRemoves);
                 $totals['enrolments'] += count($enrolments);
                 $totals['failedBatches'] += $failed;
 
                 logger()->info("moodle:sync chunk {$chunkNum}: " . count($chunkUsers) . " users, "
                     . count($cohortAdds) . " cohort adds, " . count($cohortRemoves) . " cohort removes, "
-                    . count($roles) . " roles, " . count($enrolments) . " enrolments"
+                    . count($roleAdds) . " role adds, " . count($roleRemoves) . " role removes, "
+                    . count($enrolments) . " enrolments"
                     . ($failed > 0 ? ", {$failed} sub-batches failed" : ""));
             });
 
         logger()->info("moodle:sync finished bulk pass: {$totals['users']} users seen, "
             . "{$totals['cohortAdds']} cohort adds, {$totals['cohortRemoves']} cohort removes, "
-            . "{$totals['roles']} roles, {$totals['enrolments']} enrolments across {$chunkNum} chunks, "
+            . "{$totals['roleAdds']} role adds, {$totals['roleRemoves']} role removes, "
+            . "{$totals['enrolments']} enrolments across {$chunkNum} chunks, "
             . "{$totals['failedBatches']} sub-batches permanently failed");
 
         return 0;
@@ -251,6 +262,63 @@ class MoodleSync extends Command
     }
 
     /**
+     * Diff a user's desired role assignments against their current sync-managed assignments,
+     * so we only assign roles that are missing and unassign ones that no longer apply —
+     * instead of clearing and reassigning every role every run (~1000 per dense chunk, the
+     * dominant recurring write load once cohorts were diffed). A role assignment's identity
+     * is (roleid, contextid); the desired side expresses roles as short names, mapped to
+     * role ids via the Moodle role map.
+     *
+     * End state is identical to the previous clear-then-reassign: the user ends up with
+     * exactly the desired managed roles and no others. The current set passed in must come
+     * from getManagedRoleAssignmentsForUsers(), whose filter mirrors clearUserRoles() — so
+     * only assignments the sync owns are ever removed.
+     *
+     * @param int   $id            Moodle user id
+     * @param array $desiredRoles  Each: ['uid' => int, 'cid' => int|null, 'role' => string, 'context' => string]
+     * @param array $currentManaged Each: ['roleid' => int, 'contextid' => int, 'contextlevel' => int]
+     *
+     * @return array{adds: array, removes: array}
+     */
+    private function diffRoles(int $id, array $desiredRoles, array $currentManaged): array
+    {
+        // Key desired roles by "roleid:contextid". Skip any with an unresolved role or
+        // context id — the old code would have sent those as no-op/erroring assignments.
+        $desiredByKey = [];
+        foreach ($desiredRoles as $role) {
+            $roleId = $this->moodle->roleIdFor($role['role']);
+            if ($roleId === null || $role['cid'] === null) {
+                continue;
+            }
+            $desiredByKey[$roleId . ':' . $role['cid']] = $role;
+        }
+
+        $currentByKey = [];
+        foreach ($currentManaged as $assignment) {
+            $currentByKey[$assignment['roleid'] . ':' . $assignment['contextid']] = $assignment;
+        }
+
+        $adds = $removes = [];
+        foreach ($desiredByKey as $key => $role) {
+            if (!isset($currentByKey[$key])) {
+                $adds[] = $role;
+            }
+        }
+        foreach ($currentByKey as $key => $assignment) {
+            if (!isset($desiredByKey[$key])) {
+                $removes[] = [
+                    'uid'          => $id,
+                    'roleid'       => $assignment['roleid'],
+                    'contextid'    => $assignment['contextid'],
+                    'contextlevel' => $assignment['contextlevel']
+                ];
+            }
+        }
+
+        return ['adds' => $adds, 'removes' => $removes];
+    }
+
+    /**
      * Flush a single user's computed items immediately (single-user CLI path). Reads the
      * one user's current cohort memberships to run the same diff the bulk path uses; item
      * counts never approach FLUSH_BATCH_SIZE here.
@@ -260,14 +328,21 @@ class MoodleSync extends Command
      */
     private function flushItems(int $id, array $items)
     {
-        $current = $this->moodle->getCohortMembershipsForUsers([$id])[$id] ?? [];
-        $diff = $this->diffCohorts($id, $items['cohortIdnumbers'], $current, $this->moodle->getCohortIdMap());
+        $currentCohorts = $this->moodle->getCohortMembershipsForUsers([$id])[$id] ?? [];
+        $cohortDiff = $this->diffCohorts($id, $items['cohortIdnumbers'], $currentCohorts,
+            $this->moodle->getCohortIdMap());
+
+        $currentRoles = $this->moodle->getManagedRoleAssignmentsForUsers([$id])[$id] ?? [];
+        $roleDiff = $this->diffRoles($id, $items['roles'], $currentRoles);
 
         $this->flushBulk(0, 'update', [$items['update']], fn ($items) => $this->moodle->updateUsersBulk($items));
-        $this->flushBulk(0, 'cohort-removes', $diff['removes'],
+        $this->flushBulk(0, 'cohort-removes', $cohortDiff['removes'],
             fn ($items) => $this->moodle->removeCohortsBulk($items));
-        $this->flushBulk(0, 'cohort-adds', $diff['adds'], fn ($items) => $this->moodle->assignCohortsBulk($items));
-        $this->flushBulk(0, 'roles', $items['roles'], fn ($items) => $this->moodle->assignRolesBulk($items));
+        $this->flushBulk(0, 'cohort-adds', $cohortDiff['adds'],
+            fn ($items) => $this->moodle->assignCohortsBulk($items));
+        $this->flushBulk(0, 'role-removes', $roleDiff['removes'],
+            fn ($items) => $this->moodle->unassignRolesBulk($items));
+        $this->flushBulk(0, 'role-adds', $roleDiff['adds'], fn ($items) => $this->moodle->assignRolesBulk($items));
         $this->flushBulk(0, 'enrolments', $items['enrolments'],
             fn ($items) => $this->moodle->enrolUsersBulk($items));
     }
@@ -277,8 +352,8 @@ class MoodleSync extends Command
      * enrolments — without making any HTTP calls itself. Callers accumulate these across
      * many users and flush them as bulk calls (whole-table sync), or flush a single user's
      * items immediately (single-user CLI path). Cohorts are returned as desired idnumbers
-     * and diffed against current membership by the caller (see diffCohorts()); roles are
-     * still cleared per-user here via a direct DB delete and fully reassigned.
+     * and roles as desired assignments; both are diffed against current Moodle state by the
+     * caller (see diffCohorts()/diffRoles()) so only actual changes are written.
      *
      * @param \App\User $user
      * @param int       $id Moodle user id
@@ -310,9 +385,7 @@ class MoodleSync extends Command
             $cohorts[] = "$facility-" . Helper::ratingShortFromInt($user->rating); //Facility level rating
         }
 
-        //Clear Roles
-        $this->moodle->clearUserRoles($id);
-
+        //Desired Roles (diffed against current managed assignments by the caller — no clear)
         $roles = [];
         //Assign Student Role
         foreach ($facilities as $facility) {

--- a/tests/Unit/MoodleRoleDiffTest.php
+++ b/tests/Unit/MoodleRoleDiffTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Classes\VATUSAMoodle;
+use App\Console\Commands\MoodleSync;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Pure unit test — does not boot Laravel or touch a database.
+ *
+ * MoodleSync::diffRoles() replaced the old clear-then-reassign-every-role-every-run behavior
+ * with a diff that writes only actual changes. A role assignment's identity is
+ * (roleid, contextid). These tests lock in that the diff produces the SAME end state as
+ * clear-then-reassign (user ends up with exactly the desired managed roles, no others) while
+ * emitting no writes when nothing changed.
+ */
+class MoodleRoleDiffTest extends TestCase
+{
+    /** Role short name => id, mirroring VATUSAMoodle::$roleIds for the mock. */
+    private const ROLE_IDS = ['TA' => 1, 'INS' => 4, 'STU' => 5, 'MTR' => 9, 'CBT' => 10, 'FACCBT' => 11];
+
+    private function diff(int $id, array $desired, array $current): array
+    {
+        $moodle = $this->createMock(VATUSAMoodle::class);
+        $moodle->method('roleIdFor')->willReturnCallback(fn ($role) => self::ROLE_IDS[$role] ?? null);
+        $command = new MoodleSync($moodle);
+
+        $method = new ReflectionMethod($command, 'diffRoles');
+        $method->setAccessible(true);
+
+        return $method->invoke($command, $id, $desired, $current);
+    }
+
+    private function desired(int $id, string $role, ?int $cid, string $context = 'coursecat'): array
+    {
+        return ['uid' => $id, 'cid' => $cid, 'role' => $role, 'context' => $context];
+    }
+
+    private function current(int $roleid, int $contextid, int $contextlevel = 40): array
+    {
+        return ['roleid' => $roleid, 'contextid' => $contextid, 'contextlevel' => $contextlevel];
+    }
+
+    public function test_steady_state_emits_no_writes(): void
+    {
+        // Desired INS@43 already assigned -> nothing to do.
+        $diff = $this->diff(42, [$this->desired(42, 'INS', 43)], [$this->current(4, 43)]);
+
+        $this->assertSame([], $diff['adds']);
+        $this->assertSame([], $diff['removes']);
+    }
+
+    public function test_missing_role_is_added(): void
+    {
+        $diff = $this->diff(42, [$this->desired(42, 'INS', 43), $this->desired(42, 'TA', 100)],
+            [$this->current(4, 43)]);
+
+        $this->assertSame([$this->desired(42, 'TA', 100)], $diff['adds']);
+        $this->assertSame([], $diff['removes']);
+    }
+
+    public function test_stale_managed_role_is_removed(): void
+    {
+        // User currently has MTR@500 (contextlevel course=50) that is no longer desired.
+        $diff = $this->diff(42, [$this->desired(42, 'INS', 43)],
+            [$this->current(4, 43), $this->current(9, 500, 50)]);
+
+        $this->assertSame([], $diff['adds']);
+        $this->assertSame([['uid' => 42, 'roleid' => 9, 'contextid' => 500, 'contextlevel' => 50]],
+            $diff['removes']);
+    }
+
+    public function test_add_and_remove_together(): void
+    {
+        $diff = $this->diff(42, [$this->desired(42, 'INS', 43)], [$this->current(1, 100)]);
+
+        $this->assertSame([$this->desired(42, 'INS', 43)], $diff['adds']);
+        $this->assertSame([['uid' => 42, 'roleid' => 1, 'contextid' => 100, 'contextlevel' => 40]],
+            $diff['removes']);
+    }
+
+    public function test_unknown_role_is_skipped_not_added(): void
+    {
+        // A role short name with no id mapping can't be assigned; must not appear as an add
+        // and must not spuriously remove an existing assignment.
+        $diff = $this->diff(42, [$this->desired(42, 'INS', 43), $this->desired(42, 'BOGUS', 99)],
+            [$this->current(4, 43)]);
+
+        $this->assertSame([], $diff['adds']);
+        $this->assertSame([], $diff['removes']);
+    }
+
+    public function test_null_context_desired_role_is_skipped(): void
+    {
+        // getCategoryFromShort() can return null (facility not in Moodle); such a role can't
+        // be assigned and must not be diffed.
+        $diff = $this->diff(42, [$this->desired(42, 'TA', null)], [$this->current(4, 43)]);
+
+        $this->assertSame([], $diff['adds']);
+        // The existing INS@43 is not desired -> removed (proves null-cid role didn't shadow it).
+        $this->assertSame([['uid' => 42, 'roleid' => 4, 'contextid' => 43, 'contextlevel' => 40]],
+            $diff['removes']);
+    }
+
+    public function test_duplicate_desired_roles_dedupe(): void
+    {
+        // computeSyncItems can list INS@43 twice (staff branch + instructor branch); a user
+        // not yet holding it should be added only once.
+        $diff = $this->diff(42, [$this->desired(42, 'INS', 43), $this->desired(42, 'INS', 43)], []);
+
+        $this->assertSame([$this->desired(42, 'INS', 43)], $diff['adds']);
+        $this->assertSame([], $diff['removes']);
+    }
+}


### PR DESCRIPTION
Follow-up to #114 (which diffed cohort membership). This applies the same treatment to the role path.

## Why

After #114, cohorts diffed down to near-zero writes — a full run wrote **3** net cohort changes across 25k users. But roles were still cleared and fully reassigned for every matched user every run: that same run wrote **26,997 role assignments**. Roles became the dominant recurring write load, and the source of the residual sub-batch timeouts seen on the dense chunks — each ~1,000-role chunk was enough to push the single-core mod_php Moodle droplet past the 30s client timeout.

## Change

Diff desired vs. current role assignments and write only the deltas:

- **`VATUSAMoodle::getManagedRoleAssignmentsForUsers()`** bulk-reads the sync-managed assignments for a whole chunk of users in one query. Its filter **mirrors `clearUserRoles()`'s default branch exactly** — coursecat roles, plus non-STU roles on exam courses under the VATUSA/exams context path, excluding enrolment-derived components (`enrol_cohort`/`enrol_coursecompleted`). This is the key correctness invariant: the set of assignments the sync will *remove* is identical to what clear-then-reassign deleted.
- **`VATUSAMoodle::unassignRolesBulk()`** removes stale assignments via `core_role_unassign_roles`; **`roleIdFor()`** exposes the short-name → role-id mapping for diffing.
- **`MoodleSync::diffRoles()`** diffs on `(roleid, contextid)`; `computeSyncItems()` no longer calls `clearUserRoles()` and returns desired roles for the caller to diff. Each chunk now flushes role-removes then role-adds (matching the cohort ordering).

End state is identical to clear-then-reassign — the user ends up with exactly the desired managed roles and no others — but a steady-state run writes ~zero roles. Roles with an unresolved role id or a null context id are skipped (they were no-op/erroring assignments before too).

## Notes

- `clearUserRoles()` / `clearUserCohorts()` are now unused by the sync but **retained** as public `VATUSAMoodle` methods — the `$contexts`/`$isMtr` branch of `clearUserRoles()` and related helpers remain part of the class's interface, and deleting public methods is out of scope here.
- **The #114 pacing sleep is kept.** Large *legitimate* add bursts (first-run backfill, new-ARTCC onboarding, post-outage catch-up) still fan `cacherev` bumps onto the shared hot course row, so pacing remains useful insurance even with writes diffed down. A live full run confirmed this: steady-state chunks were silent, but the newest-user tail did a one-time backfill of accumulated drift, which briefly re-formed a (smaller) `cacherev` queue.

## Testing

- `tests/Unit/MoodleRoleDiffTest.php` covers the diff semantics: steady-state no-op, add missing, remove stale, add+remove together, skip unknown role id, skip null context, dedupe duplicate desired roles.
- `php -l` clean on both changed files; full suite green (18 tests, 34 assertions).
- Same live-verification path as #114 (no isolated staging Moodle): after deploy, run a full pass and confirm the "finished bulk pass" line shows role adds/removes collapsing toward zero on subsequent runs, with `Innodb_row_lock_current_waits` staying low and per-chunk role writes in the tens rather than ~1,000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
