### PR TITLE
Restrict moodle:sync bulk pass to recently-active users

### DIFF
--- a/app/Console/Commands/MoodleSync.php
+++ b/app/Console/Commands/MoodleSync.php
@@ -42,6 +42,16 @@ class MoodleSync extends Command
      *           low enough for Moodle's DB to keep up. */
     private const FLUSH_PACING_USEC = 300000;
 
+    /** @var int The bulk pass only needs to maintain cohorts/roles for users who could
+     *           plausibly still need a change (facility/rating/staff-role updates) —
+     *           there's no reason to re-diff someone who hasn't logged into the site in
+     *           months. Restricting to recently-active users keeps the per-run row count
+     *           (and therefore Moodle write volume / cacherev contention) bounded as the
+     *           full user table keeps growing, on top of the diff-based writes from
+     *           computeSyncItems(). New-controller onboarding doesn't depend on this
+     *           filter: that's handled at login time (see cobalt's syncMoodleCohort). */
+    private const ACTIVE_WITHIN_DAYS = 90;
+
     /**
      * Create a new command instance.
      *
@@ -78,13 +88,17 @@ class MoodleSync extends Command
         //Syncronize Users
         $moodleIds = $this->moodle->getAllUserIdMap();
         $cohortIdMap = $this->moodle->getCohortIdMap();
-        logger()->info("moodle:sync starting bulk pass: {$moodleIds->count()} Moodle-linked users");
+        $activeSince = now()->subDays(self::ACTIVE_WITHIN_DAYS);
+        logger()->info("moodle:sync starting bulk pass: {$moodleIds->count()} Moodle-linked users, " .
+            "restricted to lastactivity >= {$activeSince->toDateString()}");
 
         $chunkNum = 0;
         $totals = ['users' => 0, 'cohortAdds' => 0, 'cohortRemoves' => 0,
                    'roleAdds' => 0, 'roleRemoves' => 0, 'enrolments' => 0, 'failedBatches' => 0];
 
-        User::with('visits', 'academyCompetencies.course', 'roles')->chunk(1000,
+        User::with('visits', 'academyCompetencies.course', 'roles')
+            ->where('lastactivity', '>=', $activeSince)
+            ->chunk(1000,
             function ($users) use ($moodleIds, $cohortIdMap, &$chunkNum, &$totals) {
                 $chunkNum++;
 


### PR DESCRIPTION
## Summary
- `moodle:sync`'s bulk pass (`app/Console/Commands/MoodleSync.php`) scans and diffs the *entire* `users` table (25,000+ rows) every 3 hours with no activity filter, contributing to the Moodle `mdl_course.cacherev` lock contention documented in the moodle-sync investigation, on top of the diff-based write reduction already shipped in #114/#115.
- Adds a `lastactivity >= now()-90d` filter to the bulk query. `lastactivity` is kept current by `current`'s `AuthLastActivity` middleware on every authenticated page load, so this reliably reflects real usage.
- This is a companion to a cobalt PR that adds a login-time Moodle cohort sync, replacing the dead `api` `ULSHelper::doHandleLogin` trigger as the source of truth for new-controller Observer cohort onboarding. This bulk job becomes a pure maintenance backstop (facility/rating/staff-role changes outside a fresh login) rather than the last line of defense for onboarding, so scoping it down doesn't affect new-controller latency.

## Test plan
- [x] `php -l app/Console/Commands/MoodleSync.php` (done, clean)
- [ ] Run `php artisan moodle:sync` on staging and confirm the "starting bulk pass" log line reports a reduced user count vs. before
- [ ] Confirm a manually-triggered single-user sync (`php artisan moodle:sync {cid}`) is unaffected, since the filter only applies to the bulk path
- [ ] Monitor `api-worker` logs for a full scheduled run to confirm reduced cacherev contention

🤖 Generated with [Claude Code](https://claude.com/claude-code)