### PR TITLE
Stop fetching full quiz attempt review just to read the grade

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,15 @@ Two paths (see `README.md` for full detail):
 `.env.example` is the authoritative, sectioned list of env vars (DB connections, JWT,
 VATSIM SSO/OAuth, AWS, Moodle, Swagger).
 
+**`compose.dev.yml`'s Redis does not work out of the box.** `config/database.php`'s
+`redis.default` connection hardcodes `'scheme' => 'tls'` (for the real, TLS-only managed
+Redis used in staging/prod), but the compose file's `redis:7-alpine` service is plain,
+non-TLS Redis — so anything that touches the default cache store (e.g.
+`CloudflareServiceProvider::boot()`, which runs on every request/artisan invocation) fails
+with a Predis TLS handshake error. Workaround for local runs: override
+`CACHE_DRIVER=array` (and `SESSION_DRIVER=array` if needed) rather than editing
+`config/database.php`.
+
 ### Testing & CI
 
 - Tests are **smoke tests only** right now (in-memory SQLite, no external services). Real

--- a/app/Classes/VATUSAMoodle.php
+++ b/app/Classes/VATUSAMoodle.php
@@ -62,6 +62,9 @@ class VATUSAMoodle extends MoodleRest
     /** @var array|null Memoized cohort idnumber => id map for the lifetime of this instance */
     private $cohortIdMapCache = null;
 
+    /** @var array Memoized quiz grade/sumgrades rows, keyed by quiz id */
+    private $quizMetaCache = [];
+
     /** @var int Seconds to bound each Moodle HTTP request to */
     private const HTTP_TIMEOUT_SECONDS = 30;
 
@@ -962,7 +965,31 @@ class VATUSAMoodle extends MoodleRest
     }
 
     /**
+     * Get quiz grade/sumgrades, memoized per quiz id for the lifetime of this instance.
+     *
+     * @param int $quizId The Quiz ID
+     *
+     * @return object|null
+     */
+    public
+    function getQuizMeta(
+        int $quizId
+    ) {
+        if (!array_key_exists($quizId, $this->quizMetaCache)) {
+            $this->quizMetaCache[$quizId] = DB::connection('moodle')->table('quiz')
+                ->where('id', $quizId)
+                ->first(['grade', 'sumgrades']);
+        }
+
+        return $this->quizMetaCache[$quizId];
+    }
+
+    /**
      * Get quiz attempts
+     *
+     * Grades are computed from the Moodle database (quiz.grade/sumgrades and
+     * quiz_attempts.sumgrades) rather than via the mod_quiz_get_attempt_review web service,
+     * which returns the entire rendered attempt review (~2 MB) to read a single number.
      *
      * @param int      $quizid The Quiz ID
      * @param int|null $cid    The user's CID
@@ -985,14 +1012,20 @@ class VATUSAMoodle extends MoodleRest
             $attempts = $this->request("mod_quiz_get_user_attempts",
                     ["quizid" => $quizid, "userid" => $userid])['attempts'] ?? [];
 
-            for ($i = 0; $i < count($attempts); $i++) {
-                $review = $this->request("mod_quiz_get_attempt_review",
-                        ["attemptid" => $attempts[$i]['id']]) ?? [];
-                if (!empty($review)) {
-                    $attempts[$i]['grade'] = round(floatval($review['grade']));
-                } else {
+            $quiz = $this->getQuizMeta($quizid);
+            if (!$quiz || !$quiz->sumgrades) {
+                return [];
+            }
+
+            $sumgrades = DB::connection('moodle')->table('quiz_attempts')
+                ->whereIn('id', array_column($attempts, 'id'))
+                ->pluck('sumgrades', 'id');
+
+            foreach ($attempts as $i => $attempt) {
+                if (!isset($sumgrades[$attempt['id']])) {
                     return [];
                 }
+                $attempts[$i]['grade'] = round($sumgrades[$attempt['id']] / $quiz->sumgrades * $quiz->grade);
             }
 
             return $attempts;

--- a/app/Console/Commands/SendAcademyRatingExamEmails.php
+++ b/app/Console/Commands/SendAcademyRatingExamEmails.php
@@ -144,12 +144,11 @@ class SendAcademyRatingExamEmails extends Command
                 $passingGrade = config('exams.BASIC.passingPercent');
                 $testName = "Basic ATC/S1 Exam";
 
-                $review = $this->moodle->request("mod_quiz_get_attempt_review",
-                        ["attemptid" => $attemptId]) ?? [];
-                if (empty($review)) {
+                $quiz = $this->moodle->getQuizMeta(config('exams.BASIC.id'));
+                if (!$quiz || !$quiz->sumgrades || !isset($attempt->sumgrades)) {
                     continue;
                 }
-                $grade = round(floatval($review['grade']));
+                $grade = round($attempt->sumgrades / $quiz->sumgrades * $quiz->grade);
                 $passed = $grade >= $passingGrade;
 
                 $result = compact('testName', 'studentName', 'attemptNum', 'grade',


### PR DESCRIPTION
## Summary

- `VATUSAMoodle::getQuizAttempts()` called Moodle's `mod_quiz_get_attempt_review` web service once per attempt to read a single field (`grade`) — but that endpoint returns the *entire* rendered attempt review (every question, every response, ~2.17 MB) per call.
- Driven by `moodle:competency` (every 10 min) and `moodle:sendexamemails` (every 5 min), this amounted to \~33,000 calls/day and **\~2 TB/month of outbound traffic** from `academy.vatusa.net` — \~98.6% of that droplet's total egress. This was surfaced while costing out an Azure migration: the bill for that traffic alone (~$193/mo on metered Azure egress) would exceed the entire nonprofit grant.
- The review's `grade` is just `quiz_rescale_grade(sumgrades, quiz)` = `round(sumgrades / quiz.sumgrades * quiz.grade)`. Both `sumgrades` (per attempt, in `mdl_quiz_attempts`) and `quiz.sumgrades`/`quiz.grade` (per quiz, in `mdl_quiz`) already live in the Moodle database this class already queries via `DB::connection('moodle')` for other fields — no need to go over HTTP at all.
- This PR computes the grade from the DB instead: a new `getQuizMeta()` helper (memoized per quiz id for the life of the instance) plus a single batched `whereIn` query for attempt `sumgrades`, replacing the per-attempt review call in `getQuizAttempts()`.
- Also fixes a second, independent call site in `SendAcademyRatingExamEmails.php` (the Basic ATC exam branch) that hit `mod_quiz_get_attempt_review` directly for the same reason, using the same DB-based computation.
- No behavior change for any consumer: same fields returned, same fail-closed `[]` on missing/unresolvable data.
- Added a `CLAUDE.md` note about `compose.dev.yml`'s Redis not working out of the box (`config/database.php` hardcodes `scheme: tls`, incompatible with the plain dev Redis container) — found while setting up local verification for this fix.

## Test plan

- [x] Verified in Docker (`compose.dev.yml`) against a fixture `moodle` database (`mdl_quiz`/`mdl_quiz_attempts` rows) with the real `mod_quiz_get_user_attempts` call stubbed (the only thing that stub allows — any other web-service call, e.g. the old review call, would throw): grades match the old review-derived formula exactly for both 1:1 and non-trivially-scaled quizzes, `getQuizMeta()` memoization confirmed, fail-closed behavior preserved for a missing attempt and an unknown quiz id.
- [x] `./vendor/bin/phpunit` — 18/18 passing, both natively and inside the Docker container.
- [ ] Post-deploy: confirm `mod_quiz_get_attempt_review` call volume in `academy.vatusa.net`'s Apache access log drops to ~0, and outbound bandwidth drops toward the ~300 GB/month baseline of genuine site traffic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)